### PR TITLE
feat: send more helpful error notifications

### DIFF
--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -74,13 +74,12 @@ export class ReleaseEventHandler {
               bcr,
               tag
             );
-            const branch =
-              await this.createEntryService.checkoutBranchAndCommitEntry(
-                rulesetRepo,
-                bcr,
-                tag,
-                releaser
-              );
+            const branch = await this.createEntryService.commitEntryToNewBranch(
+              rulesetRepo,
+              bcr,
+              tag,
+              releaser
+            );
             await this.createEntryService.pushEntryToFork(bcrFork, bcr, branch);
 
             console.log(

--- a/src/domain/create-entry.ts
+++ b/src/domain/create-entry.ts
@@ -58,7 +58,7 @@ export class CreateEntryService {
     );
   }
 
-  public async checkoutBranchAndCommitEntry(
+  public async commitEntryToNewBranch(
     rulesetRepo: Repository,
     bcrRepo: Repository,
     tag: string,

--- a/src/domain/error.ts
+++ b/src/domain/error.ts
@@ -1,0 +1,5 @@
+export class UserFacingError extends Error {
+  constructor(message?: string) {
+    super(message);
+  }
+}

--- a/src/domain/find-registry-fork.spec.ts
+++ b/src/domain/find-registry-fork.spec.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test, beforeEach, jest } from "@jest/globals";
 import { mocked, Mocked } from "jest-mock";
 import { GitHubClient } from "../infrastructure/github";
-import { CANONICAL_BCR, FindRegistryForkService } from "./find-registry-fork";
+import {
+  CANONICAL_BCR,
+  FindRegistryForkService,
+  NoCandidateForksError,
+} from "./find-registry-fork";
 import { Repository } from "./repository";
 import { RulesetRepository } from "./ruleset-repository";
 
@@ -192,11 +196,13 @@ describe("findCandidateForks", () => {
       }
     );
 
-    const forks = await findRegistryForkService.findCandidateForks(
-      rulesetRepo,
-      releaser
-    );
+    let thrownError!: Error;
+    try {
+      await findRegistryForkService.findCandidateForks(rulesetRepo, releaser);
+    } catch (e) {
+      thrownError = e;
+    }
 
-    expect(forks).toEqual([]);
+    expect(thrownError).toBeInstanceOf(NoCandidateForksError);
   });
 });

--- a/src/test/mock-template-files.ts
+++ b/src/test/mock-template-files.ts
@@ -1,20 +1,36 @@
 import { randomUUID } from "crypto";
 
-export function fakeModuleFile(overrides?: {
-  moduleName?: string;
-  version?: string;
-  invalidContents?: boolean;
-}): string {
+export function fakeModuleFile(
+  overrides: {
+    moduleName?: string;
+    version?: string;
+    invalidContents?: boolean;
+    deps?: boolean;
+    missingName?: boolean;
+  } = {}
+): string {
   if (overrides.invalidContents) {
     return randomUUID();
   }
-  return `\
+  let content = `\
   module(
-    name = "${overrides.moduleName || "fake_ruleset"}",
+    ${
+      overrides.missingName
+        ? ""
+        : `name = "${overrides.moduleName || "fake_ruleset"}",`
+    }
     compatibility_level = 1,
     version = "${overrides.version || "0.0.0"}",
   )
   `;
+  if (overrides.deps) {
+    content += `\
+bazel_dep(name = "bazel_skylib", version = "1.1.1")
+bazel_dep(name = "platforms", version = "0.0.4")
+`;
+  }
+
+  return content;
 }
 
 export function fakeSourceFile(


### PR DESCRIPTION
I decided not to send success notifications. Any GitHub user who wants to be notified of things probably has a notification for being tagged in a PR, which they will be for the BCR PR.

I did a first pass on error messages to include in the email. I'll have another set of errors to add for issues when creating the entry and stamping files, but I'll do that in another PR.