### PR TITLE
  feat: tag releaser in pull request instead of requesting review 

### DIFF
--- a/src/application/notifications.ts
+++ b/src/application/notifications.ts
@@ -40,7 +40,7 @@ export class NotificationsService {
   ): Promise<void> {
     await this.setAuth();
 
-    const subject = `Publish to BCR [${repoCanonicalName}]`;
+    const subject = `Publish to BCR`;
 
     let content = `\
 Failed to publish entry for ${repoCanonicalName}@${tag} to the Bazel Central Registry.

--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -23,6 +23,10 @@ export class ReleaseEventHandler {
 
   public readonly handle: HandlerFunction<"release.published", unknown> =
     async (event) => {
+      const bcr = Repository.fromCanonicalName(
+        process.env.BAZEL_CENTRAL_REGISTRY
+      );
+
       let releaser: User;
       const repoCanonicalName = `${event.payload.repository.owner.login}/${event.payload.repository.name}`;
       const tag = event.payload.release.tag_name;
@@ -65,9 +69,6 @@ export class ReleaseEventHandler {
           try {
             console.log(`Selecting fork ${bcrFork.canonicalName}.`);
 
-            const bcr = Repository.fromCanonicalName(
-              process.env.BAZEL_CENTRAL_REGISTRY
-            );
             await this.createEntryService.createEntryFiles(
               rulesetRepo,
               bcr,

--- a/src/domain/publish-entry.spec.ts
+++ b/src/domain/publish-entry.spec.ts
@@ -41,6 +41,7 @@ describe("sendRequest", () => {
       branch,
       bcr,
       "main",
+      expect.any(String),
       expect.any(String)
     );
   });
@@ -71,20 +72,20 @@ describe("sendRequest", () => {
       expect.any(String),
       expect.any(Repository),
       expect.any(String),
-      expect.stringContaining(`${rulesetRepo.canonicalName}`)
+      expect.stringContaining(`${rulesetRepo.canonicalName}`),
+      expect.any(String)
     );
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
       expect.any(Repository),
       expect.any(String),
       expect.any(Repository),
       expect.any(String),
-      expect.stringContaining(`${tag}`)
+      expect.stringContaining(`${tag}`),
+      expect.any(String)
     );
   });
 
-  test("requests a review from the releaser", async () => {
-    mockGithubClient.createPullRequest.mockReturnValueOnce(Promise.resolve(42));
-
+  test("tags the releaser in the body", async () => {
     const rulesetRepo = new Repository("foo", "bar");
     const bcrFork = new Repository("bazel-central-registry", "bar");
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
@@ -104,8 +105,40 @@ describe("sendRequest", () => {
       branch,
       releaser
     );
-    expect(mockGithubClient.requestReview).toHaveBeenCalledWith(bcr, 42, [
-      releaser.username,
-    ]);
+
+    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
+      expect.any(Repository),
+      expect.any(String),
+      expect.any(Repository),
+      expect.any(String),
+      expect.any(String),
+      expect.stringContaining(`@${releaser.username}`)
+    );
+  });
+
+  test("creates the created pull request number", async () => {
+    const rulesetRepo = new Repository("foo", "bar");
+    const bcrFork = new Repository("bazel-central-registry", "bar");
+    const bcr = new Repository("bazel-central-registry", "bazelbuild");
+    const branch = "branch_with_entry";
+    const tag = "v1.0.0";
+    const releaser = {
+      name: "Json Bearded",
+      username: "json",
+      email: "jason@foo.org",
+    };
+
+    mockGithubClient.createPullRequest.mockResolvedValueOnce(4);
+
+    const pr = await publishEntryService.sendRequest(
+      rulesetRepo,
+      tag,
+      bcrFork,
+      bcr,
+      branch,
+      releaser
+    );
+
+    expect(pr).toEqual(4);
   });
 });

--- a/src/domain/publish-entry.ts
+++ b/src/domain/publish-entry.ts
@@ -12,14 +12,19 @@ export class PublishEntryService {
     bcr: Repository,
     branch: string,
     releaser: User
-  ): Promise<void> {
-    const pullNumber = await this.githubClient.createPullRequest(
+  ): Promise<number> {
+    const pr = await this.githubClient.createPullRequest(
       bcrForkRepo,
       branch,
       bcr,
       "main",
-      `Publish ${rulesetRepo.canonicalName}@${tag}`
+      `${rulesetRepo.canonicalName}@${tag}`,
+      `\
+Release author: @${releaser.username}.
+
+Automated by [Publish to BCR](https://github.com/apps/publish-to-bcr).`
     );
-    await this.githubClient.requestReview(bcr, pullNumber, [releaser.username]);
+
+    return pr;
   }
 }

--- a/src/infrastructure/github.ts
+++ b/src/infrastructure/github.ts
@@ -69,34 +69,21 @@ export class GitHubClient {
     fromBranch: string,
     toRepo: Repository,
     toBranch: string,
-    title: string
+    title: string,
+    body: string
   ): Promise<number> {
     const app = await this.getRepoAuthorizedOctokit(toRepo);
     const { data: pull } = await app.rest.pulls.create({
       owner: toRepo.owner,
       repo: toRepo.name,
       title: title,
-      body: "Automated by [Publish to BCR](https://github.com/apps/publish-to-bcr).",
+      body,
       head: `${fromRepo.owner}:${fromBranch}`,
       base: toBranch,
       maintainer_can_modify: false,
     });
 
     return pull.number;
-  }
-
-  public async requestReview(
-    repository: Repository,
-    pullNumber: number,
-    reviewers: string[]
-  ): Promise<void> {
-    const octokit = await this.getRepoAuthorizedOctokit(repository);
-    await octokit.rest.pulls.requestReviewers({
-      owner: repository.owner,
-      repo: repository.name,
-      pull_number: pullNumber,
-      reviewers: reviewers,
-    });
   }
 
   public async getRepoUser(


### PR DESCRIPTION
Previously I was indirectly notifying the releaser by tagging them as a reviewer on the pull request. While this works for us, it will fail for most users because they are not collaborators on `bazelbuild/bazel-central-registry`.

Instead, I'm tagging their user name in the PR body so they get a mention ~and sending a success email with a link to the PR~.