### PR TITLE
feat: set login/email on fixed releaser

### DIFF
--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -1,3 +1,8 @@
 export interface Configuration {
-  readonly fixedReleaser?: string;
+  readonly fixedReleaser?: FixedReleaser;
+}
+
+export interface FixedReleaser {
+  readonly login: string;
+  readonly email: string;
 }

--- a/src/domain/ruleset-repository.spec.ts
+++ b/src/domain/ruleset-repository.spec.ts
@@ -21,6 +21,7 @@ import {
   fakeSourceFile,
 } from "../test/mock-template-files";
 import { expectThrownError } from "../test/util";
+import { FixedReleaser } from "./config";
 
 jest.mock("node:fs");
 jest.mock("../infrastructure/git");
@@ -128,9 +129,15 @@ describe("create", () => {
     });
 
     test("loads a fixedReleaser", async () => {
-      mockRulesetFiles({ configExists: true, fixedReleaser: "jbedard" });
+      mockRulesetFiles({
+        configExists: true,
+        fixedReleaser: { login: "jbedard", email: "json@bearded.ca" },
+      });
       const rulesetRepo = await RulesetRepository.create("foo", "bar", "main");
-      expect(rulesetRepo.config.fixedReleaser).toEqual("jbedard");
+      expect(rulesetRepo.config.fixedReleaser).toEqual({
+        login: "jbedard",
+        email: "json@bearded.ca",
+      });
     });
 
     test("throws on invalid fixedReleaser", async () => {
@@ -258,7 +265,7 @@ function mockRulesetFiles(
     sourceMissingUrl?: boolean;
     invalidPresubmit?: boolean;
     configExists?: boolean;
-    fixedReleaser?: string;
+    fixedReleaser?: FixedReleaser;
     invalidFixedReleaser?: boolean;
   } = {}
 ) {

--- a/src/domain/ruleset-repository.ts
+++ b/src/domain/ruleset-repository.ts
@@ -241,14 +241,19 @@ function loadConfiguration(rulesetRepo: RulesetRepository): Configuration {
     return {};
   }
 
-  let config: Record<string, unknown>;
+  let config: Record<string, any>;
   try {
     config = yaml.parse(fs.readFileSync(rulesetRepo.configFilePath, "utf-8"));
   } catch (error) {
     throw new InvalidConfigFileError(rulesetRepo, "cannot parse file as yaml");
   }
 
-  if (config.fixedReleaser && typeof config.fixedReleaser !== "string") {
+  if (
+    config.fixedReleaser &&
+    (typeof config.fixedReleaser !== "object" ||
+      typeof config.fixedReleaser.login !== "string" ||
+      typeof config.fixedReleaser.email !== "string")
+  ) {
     throw new InvalidConfigFileError(
       rulesetRepo,
       "could not parse 'fixedReleaser'"

--- a/src/test/mock-template-files.ts
+++ b/src/test/mock-template-files.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { FixedReleaser } from "../domain/config";
 
 export function fakeModuleFile(
   overrides: {
@@ -129,14 +130,21 @@ export function fakeMetadataFile(
 }
 
 export function fakeConfigFile(
-  options: { fixedReleaser?: string; invalidFixedReleaser?: boolean } = {}
+  options: {
+    fixedReleaser?: FixedReleaser;
+    invalidFixedReleaser?: boolean;
+  } = {}
 ) {
   if (options.invalidFixedReleaser) {
     return `\
-fixedReleaser: {}
+fixedReleaser: foobar
 `;
   }
   return `\
-${options.fixedReleaser ? `fixedReleaser: ${options.fixedReleaser}` : ""}
+${
+  options.fixedReleaser
+    ? `fixedReleaser: ${JSON.stringify(options.fixedReleaser)}`
+    : ""
+}
 `;
 }

--- a/templates/README.md
+++ b/templates/README.md
@@ -80,9 +80,11 @@ The `integrity` hash will automatically be filled out by the app.
 A configuration file to override default behaviour of the app.
 
 ```yaml
-fixedReleaser: <GITHUB_USERNAME>
+fixedReleaser:
+  login: <GITHUB_USERNAME>
+  email: <EMAIL>
 ```
 
-| Field         | Description                                                                                                                                                           |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| fixedReleaser | GitHub username (e.g., `kormide`) to author BCR entries. Set this if you want a single user to always be the author of BCR entries regardless of who cut the release. |
+| Field         | Description                                                                                                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| fixedReleaser | GitHub username and email to use as the author for BCR commits. Set this if you want a single user to always be the author of BCR entries regardless of who cut the release. |


### PR DESCRIPTION
Addresses: https://github.com/bazel-contrib/publish-to-bcr/issues/17

This changes the fixed releaser schema to:
```
fixedReleaser:
  login: <USER>
  email: <EMAIL>
```
Unless we add more permissions to the app, a user's email can't be fetched unless it's publicly visible on their profile. The result is that the commit on BCR doesn't have an email and could cause some tracking issues for stats in the future.

This adds a way to ensure an email gets set.

This is a breaking API change. However, since Aspect and @fmeum are the only ones using this, we can make the change safely.