### PR TITLE
fix: fix a bug where '.' strip prefixes were not extracted correctly

### DIFF
--- a/src/domain/release-archive.spec.ts
+++ b/src/domain/release-archive.spec.ts
@@ -126,6 +126,24 @@ describe("extractModuleFile", () => {
     );
   });
 
+  // See https://github.com/bazelbuild/rules_pkg/issues/50
+  test("extracts MODULE.bazel from a tarball when the strip_prefix is `.``", async () => {
+    const releaseArchive = await ReleaseArchive.fetch(
+      "https://foo.bar/rules-foo-v1.2.3.tar.gz",
+      "."
+    );
+    await releaseArchive.extractModuleFile();
+
+    expect(tar.x).toHaveBeenCalledWith(
+      {
+        cwd: path.dirname(releaseArchive.diskPath),
+        file: releaseArchive.diskPath,
+        strip: 1,
+      },
+      ["./MODULE.bazel"]
+    );
+  });
+
   test("extracts the full zip archive next to the zip archive", async () => {
     const releaseArchive = await ReleaseArchive.fetch(
       "https://foo.bar/rules-foo-v1.2.3.zip",

--- a/src/domain/release-archive.ts
+++ b/src/domain/release-archive.ts
@@ -53,13 +53,25 @@ export class ReleaseArchive {
     const stripComponents = this.stripPrefix
       ? this.stripPrefix.split("/").length
       : 0;
+
+    let modulePath: string;
+
+    if (this.stripPrefix === ".") {
+      // https://github.com/bazelbuild/rules_pkg/issues/50 means some some release archives
+      // produced with pkg_tar will have a "." prefix baked in. Using path.join will collapse
+      // "." and just produce "MODULE.bazel" which is not the correct extraction path.
+      modulePath = "./MODULE.bazel";
+    } else {
+      modulePath = path.join(this.stripPrefix, "MODULE.bazel");
+    }
+
     await tar.x(
       {
         cwd: extractDir,
         file: this._diskPath,
         strip: stripComponents,
       },
-      [path.posix.join(this.stripPrefix, "MODULE.bazel")]
+      [modulePath]
     );
   }
 


### PR DESCRIPTION
This addresses the case where people use `pkg_tar` to produce their release archive, which creates a `.` prefix by default: https://github.com/bazelbuild/rules_pkg/issues/50