### PR TITLE
fix: fix a bug where tarballs with a '.' prefix were not extracted correctly

### DIFF
--- a/src/domain/release-archive.spec.ts
+++ b/src/domain/release-archive.spec.ts
@@ -92,38 +92,32 @@ describe("extractModuleFile", () => {
     expect(thrownError.message.includes("deb")).toEqual(true);
   });
 
-  test("extracts MODULE.bazel file next to the tarball archive", async () => {
+  test("extracts contents next to the tarball archive", async () => {
     const releaseArchive = await ReleaseArchive.fetch(
       "https://foo.bar/rules-foo-v1.2.3.tar.gz",
       STRIP_PREFIX
     );
     await releaseArchive.extractModuleFile();
 
-    expect(tar.x).toHaveBeenCalledWith(
-      {
-        cwd: path.dirname(releaseArchive.diskPath),
-        file: releaseArchive.diskPath,
-        strip: 1,
-      },
-      [path.posix.join(STRIP_PREFIX, "MODULE.bazel")]
-    );
+    expect(tar.x).toHaveBeenCalledWith({
+      cwd: path.dirname(releaseArchive.diskPath),
+      file: releaseArchive.diskPath,
+      strip: 1,
+    });
   });
 
-  test("extracts MODULE.bazel from a tarball when the strip_prefix is empty", async () => {
+  test("extracts a tarball when the strip_prefix is empty", async () => {
     const releaseArchive = await ReleaseArchive.fetch(
       "https://foo.bar/rules-foo-v1.2.3.tar.gz",
       ""
     );
     await releaseArchive.extractModuleFile();
 
-    expect(tar.x).toHaveBeenCalledWith(
-      {
-        cwd: path.dirname(releaseArchive.diskPath),
-        file: releaseArchive.diskPath,
-        strip: 0,
-      },
-      ["MODULE.bazel"]
-    );
+    expect(tar.x).toHaveBeenCalledWith({
+      cwd: path.dirname(releaseArchive.diskPath),
+      file: releaseArchive.diskPath,
+      strip: 0,
+    });
   });
 
   test("extracts the full zip archive next to the zip archive", async () => {

--- a/src/domain/release-archive.ts
+++ b/src/domain/release-archive.ts
@@ -53,14 +53,11 @@ export class ReleaseArchive {
     const stripComponents = this.stripPrefix
       ? this.stripPrefix.split("/").length
       : 0;
-    await tar.x(
-      {
-        cwd: extractDir,
-        file: this._diskPath,
-        strip: stripComponents,
-      },
-      [path.posix.join(this.stripPrefix, "MODULE.bazel")]
-    );
+    await tar.x({
+      cwd: extractDir,
+      file: this._diskPath,
+      strip: stripComponents,
+    });
   }
 
   private async extractModuleFileFromZip(extractDir: string): Promise<void> {


### PR DESCRIPTION
This is a better solution than https://github.com/bazel-contrib/publish-to-bcr/pull/30

Bazel already seems to handle the `.` prefix inside of a tarball without needing a `strip_prefix` in `http_archive`. We shouldn't need ruleset authors to add this to their `source.json` file in bcr entries.

This PR fixes the issue by not trying to extract only `MODULE.bazel` from a release tarball, which required the prepended `"./" on the extraction path. Instead, extract the whole archive (like we do for zips) and let the filesystem cancel out the leading ".".