### PR TITLE
fix: fix a bug where releasers were not notified of template errors

### DIFF
--- a/src/domain/source-template.ts
+++ b/src/domain/source-template.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
-import { UserFacingError } from "./error.js";
 
-export class InvalidSourceTemplateError extends UserFacingError {
+export class InvalidSourceTemplateError extends Error {
   constructor(reason: string) {
     super(`Invalid source.template.json file: ${reason}`);
   }

--- a/src/domain/user.ts
+++ b/src/domain/user.ts
@@ -1,5 +1,5 @@
 export interface User {
-  readonly name: string;
+  readonly name?: string;
   readonly username: string;
   readonly email: string;
 }


### PR DESCRIPTION
Addresses https://github.com/bazel-contrib/publish-to-bcr/issues/32.

The issue was I wasn't setting a releaser before validating the ruleset template files so there was no one to send an email to. If there was an error validating the ruleset template files, it will still try to look for the `fixedReleaser` in the configuration file.