### PR TITLE
fix: make strip_prefix optional in the source template

### DIFF
--- a/src/domain/source-template.ts
+++ b/src/domain/source-template.ts
@@ -22,11 +22,10 @@ export class SourceTemplate {
       throw new InvalidSourceTemplateError("cannot parse file as json");
     }
 
-    if (!("strip_prefix" in this.sourceJson)) {
-      throw new InvalidSourceTemplateError("missing strip_prefix field");
-    }
-
-    if (typeof this.sourceJson.strip_prefix !== "string") {
+    if (
+      "strip_prefix" in this.sourceJson &&
+      typeof this.sourceJson.strip_prefix !== "string"
+    ) {
       throw new InvalidSourceTemplateError("invalid strip_prefix field");
     }
 
@@ -46,7 +45,9 @@ export class SourceTemplate {
     tag: string,
     version: string
   ) {
-    for (let prop of ["url", "strip_prefix"]) {
+    for (let prop of ["url", "strip_prefix"].filter(
+      (prop) => prop in this.sourceJson
+    )) {
       this.sourceJson[prop] = this.replaceVariables(
         this.sourceJson[prop] as string,
         repoOwner,
@@ -97,6 +98,6 @@ export class SourceTemplate {
   }
 
   public get stripPrefix(): string {
-    return this.sourceJson.strip_prefix as string;
+    return (this.sourceJson.strip_prefix as string) || "";
   }
 }


### PR DESCRIPTION
Addresses the error in https://github.com/bazel-contrib/publish-to-bcr/issues/32

fyi @fmeum for rules_go