### PR TITLE
fix: preserve yanked_versions in bcr metadata

### DIFF
--- a/src/domain/create-entry.ts
+++ b/src/domain/create-entry.ts
@@ -202,10 +202,12 @@ function updateMetadataFile(
   version: string
 ) {
   let publishedVersions = [];
+  let yankedVersions = {};
   if (fs.existsSync(destPath)) {
     try {
       const existingMetadata = JSON.parse(fs.readFileSync(destPath, "utf8"));
       publishedVersions = existingMetadata.versions;
+      yankedVersions = existingMetadata.yanked_versions;
     } catch (error) {
       throw new MetadataParseError(bcrRepo, destPath);
     }
@@ -221,6 +223,7 @@ function updateMetadataFile(
     })
   );
   metadata.versions = [...publishedVersions, version];
+  metadata.yanked_versions = { ...metadata.yanked_versions, ...yankedVersions };
 
   fs.writeFileSync(destPath, JSON.stringify(metadata, null, 4) + "\n");
 }

--- a/src/test/mock-template-files.ts
+++ b/src/test/mock-template-files.ts
@@ -105,6 +105,7 @@ tasks:
 export function fakeMetadataFile(
   options: {
     versions?: string[];
+    yankedVersions?: { [version: string]: string };
     homepage?: string;
     malformed?: boolean;
     missingVersions?: boolean;
@@ -128,7 +129,7 @@ export function fakeMetadataFile(
           ? ""
           : `"versions": ${JSON.stringify(options.versions || [])},`
       }
-      "yanked_versions": {}
+      "yanked_versions": ${JSON.stringify(options.yankedVersions || {})}
     }
   `;
 }


### PR DESCRIPTION
Fixes: https://github.com/bazel-contrib/publish-to-bcr/issues/35

fyi: @fmeum

