### PR TITLE
fix: fix a bug where an empty config file threw

### DIFF
--- a/src/domain/ruleset-repository.spec.ts
+++ b/src/domain/ruleset-repository.spec.ts
@@ -151,6 +151,15 @@ describe("create", () => {
         email: "json@bearded.ca",
       });
     });
+
+    test("does not complain when the config file is empty", async () => {
+      mockRulesetFiles({
+        configExists: true,
+        configContent: "",
+      });
+
+      await RulesetRepository.create("foo", "bar", "main");
+    });
   });
 });
 
@@ -224,6 +233,7 @@ function mockRulesetFiles(
     invalidPresubmit?: boolean;
     configExists?: boolean;
     configExt?: "yml" | "yaml";
+    configContent?: string;
     fixedReleaser?: FixedReleaser;
     invalidFixedReleaser?: boolean;
     invalidSourceTemplate?: boolean;
@@ -263,6 +273,7 @@ function mockRulesetFiles(
         p === path.join(templatesDir, `config.${options.configExt || "yml"}`)
       ) {
         return fakeConfigFile({
+          content: options.configContent,
           fixedReleaser: options.fixedReleaser,
           invalidFixedReleaser: options.invalidFixedReleaser,
         });

--- a/src/domain/ruleset-repository.ts
+++ b/src/domain/ruleset-repository.ts
@@ -218,7 +218,8 @@ function loadConfiguration(rulesetRepo: RulesetRepository): Configuration {
 
   let config: Record<string, any>;
   try {
-    config = yaml.parse(fs.readFileSync(rulesetRepo.configFilePath, "utf-8"));
+    config =
+      yaml.parse(fs.readFileSync(rulesetRepo.configFilePath, "utf-8")) || {};
   } catch (error) {
     throw new InvalidConfigFileError(rulesetRepo, "cannot parse file as yaml");
   }

--- a/src/test/mock-template-files.ts
+++ b/src/test/mock-template-files.ts
@@ -137,8 +137,12 @@ export function fakeConfigFile(
   options: {
     fixedReleaser?: FixedReleaser;
     invalidFixedReleaser?: boolean;
+    content?: string;
   } = {}
 ) {
+  if (options.content) {
+    return options.content;
+  }
   if (options.invalidFixedReleaser) {
     return `\
 fixedReleaser: foobar


### PR DESCRIPTION
This is especially bad because an empty config file is in the default template folder that people copy over :scream_cat: 