### PR TITLE
refactor: detect missing app installations on fork earlier

### DIFF
--- a/src/domain/create-entry.spec.ts
+++ b/src/domain/create-entry.spec.ts
@@ -4,10 +4,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { GitClient } from "../infrastructure/git";
-import {
-  GitHubClient,
-  MissingRepositoryInstallationError,
-} from "../infrastructure/github";
+import { GitHubClient } from "../infrastructure/github";
 import {
   fakeMetadataFile,
   fakeModuleFile,
@@ -16,7 +13,6 @@ import {
 } from "../test/mock-template-files";
 import { expectThrownError } from "../test/util";
 import {
-  AppNotInstalledToForkError,
   CreateEntryService,
   MetadataParseError,
   VersionAlreadyPublishedError,
@@ -741,26 +737,6 @@ describe("pushEntryToFork", () => {
       bcrRepo.diskPath,
       "authed-fork",
       branchName
-    );
-  });
-
-  test("throws when the repository installation is missing", async () => {
-    const bcrRepo = CANONICAL_BCR;
-    const bcrForkRepo = new Repository("bazel-central-registry", "aspect");
-    const branchName = `repo/owner@v1.2.3`;
-
-    mockGithubClient.getAuthenticatedRemoteUrl.mockRejectedValueOnce(
-      new MissingRepositoryInstallationError(bcrForkRepo)
-    );
-
-    const thrownError = await expectThrownError(
-      () =>
-        createEntryService.pushEntryToFork(bcrForkRepo, bcrRepo, branchName),
-      AppNotInstalledToForkError
-    );
-
-    expect(thrownError.message.includes(bcrForkRepo.canonicalName)).toEqual(
-      true
     );
   });
 });

--- a/src/domain/create-entry.ts
+++ b/src/domain/create-entry.ts
@@ -3,10 +3,7 @@ import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { GitClient } from "../infrastructure/git.js";
-import {
-  GitHubClient,
-  MissingRepositoryInstallationError,
-} from "../infrastructure/github.js";
+import { GitHubClient } from "../infrastructure/github.js";
 import { UserFacingError } from "./error.js";
 import { computeIntegrityHash } from "./integrity-hash.js";
 import { ModuleFile } from "./module-file.js";
@@ -26,14 +23,6 @@ export class MetadataParseError extends UserFacingError {
   public constructor(repository: Repository, path: string) {
     super(
       `Could not parse metadata file ${path} from repository ${repository.canonicalName}.`
-    );
-  }
-}
-
-export class AppNotInstalledToForkError extends UserFacingError {
-  public constructor(repository: Repository) {
-    super(
-      `App is not installed to candidate bcr fork ${repository.canonicalName}. You need to configure the app for at least one bazel-central-registry fork. The fork can be in the ruleset's account in the release author's account.`
     );
   }
 }
@@ -137,17 +126,8 @@ export class CreateEntryService {
     bcr: Repository,
     branch: string
   ): Promise<void> {
-    let authenticatedRemoteUrl: string;
-
-    try {
-      authenticatedRemoteUrl =
-        await this.githubClient.getAuthenticatedRemoteUrl(bcrForkRepo);
-    } catch (error) {
-      if (error instanceof MissingRepositoryInstallationError) {
-        throw new AppNotInstalledToForkError(bcrForkRepo);
-      }
-      throw error;
-    }
+    const authenticatedRemoteUrl =
+      await this.githubClient.getAuthenticatedRemoteUrl(bcrForkRepo);
 
     await this.gitClient.addRemote(
       bcr.diskPath,

--- a/src/infrastructure/github.ts
+++ b/src/infrastructure/github.ts
@@ -101,6 +101,18 @@ export class GitHubClient {
     return { name: data.name, username, email: data.email };
   }
 
+  public async hasAppInstallation(repository: Repository): Promise<boolean> {
+    try {
+      await this.getRepositoryInstallation(repository);
+      return true;
+    } catch (error) {
+      if (error instanceof MissingRepositoryInstallationError) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
   private async getRepositoryInstallation(
     repository: Repository
   ): Promise<any> {


### PR DESCRIPTION
Currently we find candidate BCR forks to push to, then try the whole workflow in a loop. There's no point even attempting to publish an entry to a fork that doesn't have the app installed to it. Detect this earlier and improve the email we send to users. Forgetting to install the app to a fork is the most common issue new users have.