### PR TITLE
Revert "refactor: avoid downloading entire repository histories"

### DIFF
--- a/src/domain/repository.spec.ts
+++ b/src/domain/repository.spec.ts
@@ -51,8 +51,7 @@ describe("checkout", () => {
     await repository.checkout("main");
     expect(Repository.gitClient.clone).toHaveBeenCalledWith(
       repository.url,
-      repository.diskPath,
-      "main"
+      repository.diskPath
     );
     expect(Repository.gitClient.checkout).toHaveBeenCalledWith(
       repository.diskPath,
@@ -65,8 +64,7 @@ describe("checkout", () => {
     await repository.checkout();
     expect(Repository.gitClient.clone).toHaveBeenCalledWith(
       repository.url,
-      repository.diskPath,
-      undefined
+      repository.diskPath
     );
     expect(Repository.gitClient.checkout).toHaveBeenCalledWith(
       repository.diskPath,

--- a/src/domain/repository.ts
+++ b/src/domain/repository.ts
@@ -32,13 +32,13 @@ export class Repository {
     return this._diskPath;
   }
 
-  public async checkout(branch?: string): Promise<void> {
+  public async checkout(ref?: string): Promise<void> {
     if (!this.isCheckedOut()) {
       this._diskPath = path.join(os.tmpdir(), randomUUID(), this.name);
-      await Repository.gitClient.clone(this.url, this._diskPath, branch);
+      await Repository.gitClient.clone(this.url, this._diskPath);
     }
 
-    await Repository.gitClient.checkout(this._diskPath, branch);
+    await Repository.gitClient.checkout(this._diskPath, ref);
   }
 
   public equals(other: Repository): boolean {

--- a/src/infrastructure/git.ts
+++ b/src/infrastructure/git.ts
@@ -1,16 +1,8 @@
 import { simpleGit } from "simple-git";
 
 export class GitClient {
-  public async clone(
-    url: string,
-    repoPath: string,
-    branch?: string
-  ): Promise<void> {
-    const options = ["--depth", "1"];
-    if (branch) {
-      options.push("--branch", branch);
-    }
-    await simpleGit().clone(url, repoPath, options);
+  public async clone(url: string, repoPath: string): Promise<void> {
+    await simpleGit().clone(url, repoPath);
   }
 
   public async checkout(repoPath: string, ref?: string): Promise<void> {


### PR DESCRIPTION
Reverts bazel-contrib/publish-to-bcr#42

This caused a couple of releases to fail.

Apparently you can't push from shallow clones: https://stackoverflow.com/a/28985327, so it failed when pushing a branch to the bcr fork.