### PR TITLE
feat: support publishing multiple modules per repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Publish to BCR uses information about the GitHub author of a release in order to
 
 You can work around this by setting a [fixed releaser](./templates/README.md#optional-configyml).
 
+## Publishing modules in the same repo
+
+You can publish BCR entries for multiple modules that exist in your git repository by configuring [`moduleRoots`](./templates/README.md#optional-configyml).
+
 ## Reporting issues
 
 Create an issue in this repository for support.

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -1,5 +1,6 @@
 export interface Configuration {
   readonly fixedReleaser?: FixedReleaser;
+  readonly moduleRoots: string[];
 }
 
 export interface FixedReleaser {

--- a/src/domain/publish-entry.spec.ts
+++ b/src/domain/publish-entry.spec.ts
@@ -16,7 +16,6 @@ beforeEach(() => {
 
 describe("sendRequest", () => {
   test("creates a pull request from the bcr fork's provided branch to 'main' on the bcr", async () => {
-    const rulesetRepo = new Repository("foo", "bar");
     const bcrFork = new Repository("bazel-central-registry", "bar");
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
@@ -28,12 +27,12 @@ describe("sendRequest", () => {
     };
 
     await publishEntryService.sendRequest(
-      rulesetRepo,
       tag,
       bcrFork,
       bcr,
       branch,
-      releaser
+      releaser,
+      "rules_foo"
     );
 
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
@@ -46,8 +45,7 @@ describe("sendRequest", () => {
     );
   });
 
-  test("includes the ruleset repository name and tag in the PR title", async () => {
-    const rulesetRepo = new Repository("foo", "bar");
+  test("includes the module name and release version in the PR title", async () => {
     const bcrFork = new Repository("bazel-central-registry", "bar");
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
@@ -59,12 +57,12 @@ describe("sendRequest", () => {
     };
 
     await publishEntryService.sendRequest(
-      rulesetRepo,
       tag,
       bcrFork,
       bcr,
       branch,
-      releaser
+      releaser,
+      "rules_foo"
     );
 
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
@@ -72,7 +70,7 @@ describe("sendRequest", () => {
       expect.any(String),
       expect.any(Repository),
       expect.any(String),
-      expect.stringContaining(`${rulesetRepo.canonicalName}`),
+      expect.stringContaining("rules_foo"),
       expect.any(String)
     );
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
@@ -80,13 +78,12 @@ describe("sendRequest", () => {
       expect.any(String),
       expect.any(Repository),
       expect.any(String),
-      expect.stringContaining(`${tag}`),
+      expect.stringContaining("1.0.0"),
       expect.any(String)
     );
   });
 
   test("tags the releaser in the body", async () => {
-    const rulesetRepo = new Repository("foo", "bar");
     const bcrFork = new Repository("bazel-central-registry", "bar");
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
@@ -98,12 +95,12 @@ describe("sendRequest", () => {
     };
 
     await publishEntryService.sendRequest(
-      rulesetRepo,
       tag,
       bcrFork,
       bcr,
       branch,
-      releaser
+      releaser,
+      "rules_foo"
     );
 
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
@@ -117,7 +114,6 @@ describe("sendRequest", () => {
   });
 
   test("creates the created pull request number", async () => {
-    const rulesetRepo = new Repository("foo", "bar");
     const bcrFork = new Repository("bazel-central-registry", "bar");
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
@@ -131,12 +127,12 @@ describe("sendRequest", () => {
     mockGithubClient.createPullRequest.mockResolvedValueOnce(4);
 
     const pr = await publishEntryService.sendRequest(
-      rulesetRepo,
       tag,
       bcrFork,
       bcr,
       branch,
-      releaser
+      releaser,
+      "rules_foo"
     );
 
     expect(pr).toEqual(4);

--- a/src/domain/publish-entry.ts
+++ b/src/domain/publish-entry.ts
@@ -1,24 +1,26 @@
 import { GitHubClient } from "../infrastructure/github.js";
 import { Repository } from "./repository.js";
+import { RulesetRepository } from "./ruleset-repository.js";
 import { User } from "./user.js";
 
 export class PublishEntryService {
   constructor(private readonly githubClient: GitHubClient) {}
 
   public async sendRequest(
-    rulesetRepo: Repository,
     tag: string,
     bcrForkRepo: Repository,
     bcr: Repository,
     branch: string,
-    releaser: User
+    releaser: User,
+    moduleName: string
   ): Promise<number> {
+    const version = RulesetRepository.getVersionFromTag(tag);
     const pr = await this.githubClient.createPullRequest(
       bcrForkRepo,
       branch,
       bcr,
       "main",
-      `${rulesetRepo.canonicalName}@${tag}`,
+      `${moduleName}@${version}`,
       `\
 Release author: @${releaser.username}.
 

--- a/src/domain/release-archive.spec.ts
+++ b/src/domain/release-archive.spec.ts
@@ -127,7 +127,7 @@ describe("extractModuleFile", () => {
     );
 
     const thrownError = await expectThrownError(
-      () => releaseArchive.extractModuleFile(),
+      () => releaseArchive.extractModuleFile("."),
       UnsupportedArchiveFormat
     );
     expect(thrownError.message.includes("deb")).toEqual(true);
@@ -138,7 +138,7 @@ describe("extractModuleFile", () => {
       "https://foo.bar/rules-foo-v1.2.3.tar.gz",
       STRIP_PREFIX
     );
-    await releaseArchive.extractModuleFile();
+    await releaseArchive.extractModuleFile(".");
 
     expect(tar.x).toHaveBeenCalledWith({
       cwd: path.dirname(releaseArchive.diskPath),
@@ -152,7 +152,7 @@ describe("extractModuleFile", () => {
       "https://foo.bar/rules-foo-v1.2.3.tar.gz",
       ""
     );
-    await releaseArchive.extractModuleFile();
+    await releaseArchive.extractModuleFile(".");
 
     expect(tar.x).toHaveBeenCalledWith({
       cwd: path.dirname(releaseArchive.diskPath),
@@ -166,7 +166,7 @@ describe("extractModuleFile", () => {
       "https://foo.bar/rules-foo-v1.2.3.zip",
       STRIP_PREFIX
     );
-    await releaseArchive.extractModuleFile();
+    await releaseArchive.extractModuleFile(".");
 
     expect(extractZip).toHaveBeenCalledWith(releaseArchive.diskPath, {
       dir: path.dirname(releaseArchive.diskPath),
@@ -186,10 +186,26 @@ describe("extractModuleFile", () => {
       RELEASE_ARCHIVE_URL,
       STRIP_PREFIX
     );
-    await releaseArchive.extractModuleFile();
+    await releaseArchive.extractModuleFile(".");
 
     const expectedPath = path.join(
       path.dirname(releaseArchive.diskPath),
+      "MODULE.bazel"
+    );
+    expect(fs.readFileSync).toHaveBeenCalledWith(expectedPath, "utf8");
+  });
+
+  test("loads an extracted MODULE.bazel file in a different module root", async () => {
+    const releaseArchive = await ReleaseArchive.fetch(
+      RELEASE_ARCHIVE_URL,
+      STRIP_PREFIX
+    );
+    await releaseArchive.extractModuleFile("sub/dir");
+
+    const expectedPath = path.join(
+      path.dirname(releaseArchive.diskPath),
+      "sub",
+      "dir",
       "MODULE.bazel"
     );
     expect(fs.readFileSync).toHaveBeenCalledWith(expectedPath, "utf8");
@@ -200,7 +216,7 @@ describe("extractModuleFile", () => {
       RELEASE_ARCHIVE_URL,
       STRIP_PREFIX
     );
-    const moduleFile = await releaseArchive.extractModuleFile();
+    const moduleFile = await releaseArchive.extractModuleFile(".");
 
     expect(moduleFile.moduleName).toEqual("rules_foo");
     expect(moduleFile.version).toEqual("1.2.3");

--- a/src/domain/release-archive.ts
+++ b/src/domain/release-archive.ts
@@ -40,7 +40,7 @@ export class ReleaseArchive {
     private readonly stripPrefix: string
   ) {}
 
-  public async extractModuleFile(): Promise<ModuleFile> {
+  public async extractModuleFile(moduleRoot: string): Promise<ModuleFile> {
     const extractDir = path.dirname(this._diskPath);
 
     if (this._diskPath.endsWith(".tar.gz")) {
@@ -52,7 +52,11 @@ export class ReleaseArchive {
       throw new UnsupportedArchiveFormat(extension);
     }
 
-    const extractedModulePath = path.join(extractDir, "MODULE.bazel");
+    const extractedModulePath = path.join(
+      extractDir,
+      moduleRoot,
+      "MODULE.bazel"
+    );
     return new ModuleFile(extractedModulePath);
   }
 

--- a/src/infrastructure/git.ts
+++ b/src/infrastructure/git.ts
@@ -33,6 +33,12 @@ export class GitClient {
     await simpleGit(repoPath).add("./*").commit(commitMsg);
   }
 
+  public async hasRemote(repoPath: string, remote: string): Promise<boolean> {
+    return (await simpleGit(repoPath).getRemotes()).some(
+      (r) => r.name === remote
+    );
+  }
+
   public async addRemote(
     repoPath: string,
     remote: string,

--- a/templates/README.md
+++ b/templates/README.md
@@ -94,3 +94,5 @@ fixedReleaser:
 | Field         | Description                                                                                                                                                                  |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | fixedReleaser | GitHub username and email to use as the author for BCR commits. Set this if you want a single user to always be the author of BCR entries regardless of who cut the release. |
+| moduleRoots | List of relative paths to Bazel modules within the repository. Set this if your MODULE.bazel file is not in the root directory, or if you want to publish multiple modules to the BCR. Defaults to `["."]`. Each module root must have a corresponding set of template files (metadata.template.json, source.template.json, presubmit.yml) under `.bcr` with the same relative path as the module. For example, if `moduleRoots` is `[".", "sub/module"]`, then there must be separate sets of template files under `.bcr` and `.bcr/sub/module`.  |
+


### PR DESCRIPTION
Addresses #46 

This is to support rules_python and skylib publishing multiple modules on a release.

Examples of PRs created for rules_python fork:

https://github.com/publish-to-bcr-dev-registry/bazel-central-registry/pull/53
https://github.com/publish-to-bcr-dev-registry/bazel-central-registry/pull/54