### PR TITLE
feat: add patches to bcr entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ You can work around this by setting a [fixed releaser](./templates/README.md#opt
 
 You can publish BCR entries for multiple modules that exist in your git repository by configuring [`moduleRoots`](./templates/README.md#optional-configyml).
 
+## Including patches
+
+Include patches in the BCR entry by adding them under `.bcr/patches` in your ruleset repository. All patches must have the `.patch` extension and be in the `-p1` format.
+
+For example, a patch in `.bcr/patches/remove_dev_deps.patch` will be included in the entry's pull request and will be referenced in the
+corresponding `source.json` file:
+
+```json
+{
+    ...
+    "patch_strip": 0,
+    "patches": {
+        "remove_dev_deps.patch": "sha256-DXvBJbXZWf3hITOIjeJbgER6UOXIB6ogpgullT+oP4k="
+    }
+}
+```
+
+To patch in a submodule, add the patch to a patches folder under the submodule path `.bcr/[sub/module]/patches` where sub/module is the path to the WORKSPACE folder relative to the repository root.
+
 ## Reporting issues
 
 Create an issue in this repository for support.

--- a/src/domain/ruleset-repository.spec.ts
+++ b/src/domain/ruleset-repository.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, jest, test } from "@jest/globals";
-import { mocked, Mocked } from "jest-mock";
+import { Mocked, mocked } from "jest-mock";
 import fs from "node:fs";
 import path from "node:path";
 import { GitClient } from "../infrastructure/git";
@@ -347,6 +347,36 @@ describe("sourceTemplatePath", () => {
         "sub",
         "dir",
         "source.template.json"
+      )
+    );
+  });
+});
+
+describe("patchesPath", () => {
+  test("gets path to the patches folder", async () => {
+    mockRulesetFiles();
+    const rulesetRepo = await RulesetRepository.create("foo", "bar", "main");
+
+    expect(rulesetRepo.patchesPath(".")).toEqual(
+      path.join(
+        rulesetRepo.diskPath,
+        RulesetRepository.BCR_TEMPLATE_DIR,
+        "patches"
+      )
+    );
+  });
+
+  test("gets path to the patches in a different module root", async () => {
+    mockRulesetFiles();
+    const rulesetRepo = await RulesetRepository.create("foo", "bar", "main");
+
+    expect(rulesetRepo.patchesPath("sub/dir")).toEqual(
+      path.join(
+        rulesetRepo.diskPath,
+        RulesetRepository.BCR_TEMPLATE_DIR,
+        "sub",
+        "dir",
+        "patches"
       )
     );
   });

--- a/src/domain/ruleset-repository.ts
+++ b/src/domain/ruleset-repository.ts
@@ -187,6 +187,15 @@ export class RulesetRepository extends Repository {
     );
   }
 
+  public patchesPath(moduleRoot: string): string {
+    return path.resolve(
+      this.diskPath,
+      RulesetRepository.BCR_TEMPLATE_DIR,
+      moduleRoot,
+      "patches"
+    );
+  }
+
   public sourceTemplate(moduleRoot: string): SourceTemplate {
     return this._sourceTemplate[moduleRoot];
   }


### PR DESCRIPTION
Fixes https://github.com/bazel-contrib/publish-to-bcr/issues/49.

Allows arbitrary patches to be added to BCR releases. All patches must have the same strip prefix, so standardizing on `-p1`.