### PR TITLE
fix: apply patches to entry module file

### DIFF
--- a/src/domain/module-file.ts
+++ b/src/domain/module-file.ts
@@ -1,3 +1,4 @@
+import { ParsedDiff, applyPatch } from "diff";
 import fs from "node:fs";
 
 export class ModuleFile {
@@ -33,5 +34,9 @@ export class ModuleFile {
 
   public save(destPath: string) {
     fs.writeFileSync(destPath, this.moduleContent);
+  }
+
+  public patchContent(patch: ParsedDiff): void {
+    this.moduleContent = applyPatch(this.moduleContent, patch);
   }
 }

--- a/src/test/mock-template-files.ts
+++ b/src/test/mock-template-files.ts
@@ -14,16 +14,16 @@ export function fakeModuleFile(
     return randomUUID();
   }
   let content = `\
-  module(
-    ${
-      overrides.missingName
-        ? ""
-        : `name = "${overrides.moduleName || "fake_ruleset"}",`
-    }
-    compatibility_level = 1,
-    version = "${overrides.version || "0.0.0"}",
-  )
-  `;
+module(
+  ${
+    overrides.missingName
+      ? ""
+      : `name = "${overrides.moduleName || "fake_ruleset"}",`
+  }
+  compatibility_level = 1,
+  version = "${overrides.version || "0.0.0"}",
+)
+`;
   if (overrides.deps) {
     content += `\
 bazel_dep(name = "bazel_skylib", version = "1.1.1")


### PR DESCRIPTION
If an included patch patches MODULE.bazel, then it needs to be applied to the copy of MODULE.bazel in the bcr entry because it must be identical to the extracted-and-patched version.

Closes https://github.com/bazel-contrib/publish-to-bcr/issues/57.

Example entry: https://github.com/publish-to-bcr-dev-registry/bazel-central-registry/pull/63/files