### PR TITLE
fix: increase ram

### DIFF
--- a/deployment/modules/webhook/main.tf
+++ b/deployment/modules/webhook/main.tf
@@ -37,7 +37,7 @@ resource "google_cloudfunctions_function" "publish_to_bcr_function" {
   description = "Handle incoming github events"
   runtime     = "nodejs16"
 
-  available_memory_mb   = 256
+  available_memory_mb   = 512
   source_archive_bucket = google_storage_bucket.source_archive_bucket.name
   source_archive_object = google_storage_bucket_object.publish_to_bcr_function_bucket_object.name
   trigger_http          = true


### PR DESCRIPTION
A ruleset release crashed the cloud function because it ran out of memory. Increase to 512MB.