### PR TITLE
feat: notify maintainers of releases and issues

### DIFF
--- a/src/application/cloudfunction/github-webhook-entrypoint.ts
+++ b/src/application/cloudfunction/github-webhook-entrypoint.ts
@@ -21,7 +21,8 @@ const createEntryService = new CreateEntryService(gitClient, githubClient);
 const publishEntryService = new PublishEntryService(githubClient);
 const notificationsService = new NotificationsService(
   emailClient,
-  secretsClient
+  secretsClient,
+  githubClient
 );
 
 const releaseEventHandler = new ReleaseEventHandler(

--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -49,7 +49,7 @@ export class ReleaseEventHandler {
         event.payload.sender.login,
         repository
       );
-      const releaseUrl = event.payload.release.url;
+      const releaseUrl = event.payload.release.html_url;
 
       const tag = event.payload.release.tag_name;
 

--- a/src/domain/metadata-file.spec.ts
+++ b/src/domain/metadata-file.spec.ts
@@ -333,3 +333,125 @@ describe("save", () => {
     expect(JSON.parse(written).maintainers[0].disposition).toEqual("bearded");
   });
 });
+
+describe("emergencyParseMaintainers", () => {
+  test("parses maintainers from a valid metadata file", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [
+        {
+            "name": "M1",
+            "email": "m1@foo-maintainer.ca"
+        },
+        {
+            "name": "M2"
+        },
+        {
+            "name": "M3",
+            "github": "m3"
+        },
+        {
+            "name": "M4",
+            "email": "m4@foo-maintainer.ca",
+            "github": "m4"
+        }
+    ],
+    "repository":   [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+`);
+    const maintainers = MetadataFile.emergencyParseMaintainers("metadata.json");
+
+    expect(maintainers).toEqual([
+      {
+        name: "M1",
+        email: "m1@foo-maintainer.ca",
+      },
+      {
+        name: "M2",
+      },
+      {
+        name: "M3",
+        github: "m3",
+      },
+      {
+        name: "M4",
+        email: "m4@foo-maintainer.ca",
+        github: "m4",
+      },
+    ]);
+  });
+
+  test("parses valid maintainers from an invalid metadata file", () => {
+    mockMetadataFile(`\
+{
+    "versions": 42,
+    "maintainers": [
+        {
+            "name": "M1",
+            "email": "m1@foo-maintainer.ca"
+        },
+        {
+            "name": "M2"
+        }
+    ]
+}
+`);
+    const maintainers = MetadataFile.emergencyParseMaintainers("metadata.json");
+
+    expect(maintainers).toEqual([
+      {
+        name: "M1",
+        email: "m1@foo-maintainer.ca",
+      },
+      {
+        name: "M2",
+      },
+    ]);
+  });
+
+  test("ignores invalid maintainers", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [
+        {
+            "name": "M1",
+            "email": "m1@foo-maintainer.ca"
+        },
+        {
+            "email": "m2@foo-maintainer.ca"
+        },
+        {
+            "name": "M3",
+            "github": "m3"
+        },
+        {
+            "foo": "bar"
+        }
+    ],
+    "repository":   [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+`);
+    const maintainers = MetadataFile.emergencyParseMaintainers("metadata.json");
+
+    expect(maintainers).toEqual([
+      {
+        name: "M1",
+        email: "m1@foo-maintainer.ca",
+      },
+      {
+        name: "M3",
+        github: "m3",
+      },
+    ]);
+  });
+});

--- a/src/domain/metadata-file.ts
+++ b/src/domain/metadata-file.ts
@@ -106,4 +106,30 @@ export class MetadataFile {
       `${JSON.stringify(this.metadata, undefined, 4)}\n`
     );
   }
+
+  // In an already erroneous situation, just try to fetch as many `maintainers`
+  // as we can from a metadata.json file, ignoring most of the usual validation.
+  public static emergencyParseMaintainers(filepath: string): Maintainer[] {
+    try {
+      const content = fs.readFileSync(filepath, "utf8");
+      const json = JSON.parse(content);
+
+      const maintainers: Maintainer[] = [];
+      if ("maintainers" in json) {
+        if (!Array.isArray(json.maintainers)) {
+          return [];
+        }
+
+        for (const maintainer of json.maintainers) {
+          if (typeof maintainer.name === "string") {
+            maintainers.push(maintainer as Maintainer);
+          }
+        }
+
+        return maintainers;
+      }
+    } catch (e) {}
+
+    return [];
+  }
 }

--- a/src/domain/publish-entry.spec.ts
+++ b/src/domain/publish-entry.spec.ts
@@ -31,6 +31,7 @@ describe("sendRequest", () => {
       bcr,
       branch,
       releaser,
+      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
@@ -62,6 +63,7 @@ describe("sendRequest", () => {
       bcr,
       branch,
       releaser,
+      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
@@ -101,6 +103,7 @@ describe("sendRequest", () => {
       bcr,
       branch,
       releaser,
+      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
@@ -115,7 +118,7 @@ describe("sendRequest", () => {
     );
   });
 
-  test("incliudes the release url in the body", async () => {
+  test("includes the release url in the body", async () => {
     const bcrFork = new Repository("bazel-central-registry", "bar");
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
@@ -132,6 +135,7 @@ describe("sendRequest", () => {
       bcr,
       branch,
       releaser,
+      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
@@ -146,6 +150,73 @@ describe("sendRequest", () => {
         `github.com/aspect-build/rules_foo/releases/tag/${tag}`
       )
     );
+  });
+
+  test("tags all maintainers with github handles in the body", async () => {
+    const bcrFork = new Repository("bazel-central-registry", "bar");
+    const bcr = new Repository("bazel-central-registry", "bazelbuild");
+    const branch = "branch_with_entry";
+    const tag = "v1.0.0";
+    const releaser = {
+      name: "Json Bearded",
+      username: "json",
+      email: "jason@foo.org",
+    };
+    const maintainers = [
+      { name: "M1", github: "m1" },
+      { name: "M2", email: "m2@foo-maintainer.org" },
+      { name: "M3", github: "m3", email: "m3@foo-maintainer.org" },
+      { name: "M4" },
+    ];
+
+    await publishEntryService.sendRequest(
+      tag,
+      bcrFork,
+      bcr,
+      branch,
+      releaser,
+      maintainers,
+      "rules_foo",
+      `github.com/aspect-build/rules_foo/releases/tag/${tag}`
+    );
+
+    const body = mockGithubClient.createPullRequest.mock.calls[0][5];
+    expect(body.includes("@m1")).toEqual(true);
+    expect(body.includes("@m2")).toEqual(false);
+    expect(body.includes("@m3")).toEqual(true);
+    expect(body.includes("@m4")).toEqual(false);
+  });
+
+  test("does not double tag the release author if they are also a maintainer", async () => {
+    const bcrFork = new Repository("bazel-central-registry", "bar");
+    const bcr = new Repository("bazel-central-registry", "bazelbuild");
+    const branch = "branch_with_entry";
+    const tag = "v1.0.0";
+    const releaser = {
+      name: "Json Bearded",
+      username: "json",
+      email: "jason@foo.org",
+    };
+    const maintainers = [
+      { name: "M1", github: "m1" },
+      { name: releaser.name, github: releaser.username },
+    ];
+
+    await publishEntryService.sendRequest(
+      tag,
+      bcrFork,
+      bcr,
+      branch,
+      releaser,
+      maintainers,
+      "rules_foo",
+      `github.com/aspect-build/rules_foo/releases/tag/${tag}`
+    );
+
+    const body = mockGithubClient.createPullRequest.mock.calls[0][5];
+    expect(
+      (body.match(new RegExp(`@${releaser.username}`, "gm")) || []).length
+    ).toEqual(1);
   });
 
   test("creates the created pull request number", async () => {
@@ -167,6 +238,7 @@ describe("sendRequest", () => {
       bcr,
       branch,
       releaser,
+      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );

--- a/src/domain/publish-entry.ts
+++ b/src/domain/publish-entry.ts
@@ -32,7 +32,7 @@ export class PublishEntryService {
       "main",
       `${moduleName}@${version}`,
       `\
-Release: [${tag}](${releaseUrl})
+Release: ${releaseUrl}
 
 Author: @${releaser.username}
 

--- a/src/domain/publish-entry.ts
+++ b/src/domain/publish-entry.ts
@@ -1,4 +1,5 @@
 import { GitHubClient } from "../infrastructure/github.js";
+import { Maintainer } from "./metadata-file.js";
 import { Repository } from "./repository.js";
 import { RulesetRepository } from "./ruleset-repository.js";
 import { User } from "./user.js";
@@ -12,10 +13,17 @@ export class PublishEntryService {
     bcr: Repository,
     branch: string,
     releaser: User,
+    maintainers: ReadonlyArray<Maintainer>,
     moduleName: string,
     releaseUrl: string
   ): Promise<number> {
     const version = RulesetRepository.getVersionFromTag(tag);
+
+    // Only tag maintainers that have a github handle, which is optional:
+    // See: https://docs.google.com/document/d/1moQfNcEIttsk6vYanNKIy3ZuK53hQUFq1b1r0rmsYVg/edit#bookmark=id.1i90c6c14zvx
+    const maintainersToTag = maintainers
+      .filter((m) => !!m.github && m.github !== releaser.username)
+      .map((m) => `@${m.github}`);
 
     const pr = await this.githubClient.createPullRequest(
       bcrForkRepo,
@@ -26,9 +34,11 @@ export class PublishEntryService {
       `\
 Release: [${tag}](${releaseUrl})
 
-Author: @${releaser.username}.
+Author: @${releaser.username}
 
-Automated by [Publish to BCR](https://github.com/apps/publish-to-bcr).`
+${maintainersToTag.length > 0 ? "fyi: " + maintainersToTag.join(", ") : ""}
+
+_Automated by [Publish to BCR](https://github.com/apps/publish-to-bcr)_`
     );
 
     return pr;

--- a/src/infrastructure/email.ts
+++ b/src/infrastructure/email.ts
@@ -26,7 +26,7 @@ export class EmailClient {
   }
 
   public async sendEmail(
-    to: string,
+    to: string[],
     from: string,
     subject: string,
     text: string,
@@ -43,7 +43,7 @@ export class EmailClient {
     });
 
     await transporter.sendMail({
-      to,
+      to: to.join(","),
       from,
       subject,
       text,

--- a/templates/.bcr/metadata.template.json
+++ b/templates/.bcr/metadata.template.json
@@ -2,9 +2,9 @@
   "homepage": "INSERT_YOUR_HOMEPAGE",
   "maintainers": [
     {
+      "name": "INSERT_YOUR_NAME",
       "email": "INSERT_YOUR_EMAIL",
-      "github": "INSERT_YOUR_GITHUB_ORG_OR_USERNAME",
-      "name": "INSERT_YOUR_NAME"
+      "github": "INSERT_YOUR_GITHUB_USERNAME"
     }
   ],
   "repository": [

--- a/templates/README.md
+++ b/templates/README.md
@@ -14,15 +14,17 @@ For more information about the files that make up a BCR entry, see the [Bzlmod U
 Insert your ruleset's homepage and fill out the list of maintainers. Replace `OWNER/REPO` with your repository's
 canonical name. Leave `versions` alone as this will be filled automatically.
 
+_Note_: Maintainers will be emailed if any releases fail and will be tagged on the BCR pull request.
+
 ```jsonc
 {
   "homepage": "INSERT_YOUR_HOMEPAGE", // <-- Edit this
   "maintainers": [
     {
       // <-- And this
+      "name": "INSERT_YOUR_NAME",
       "email": "INSERT_YOUR_EMAIL",
-      "github": "INSERT_YOUR_GITHUB_ORG_OR_USERNAME",
-      "name": "INSERT_YOUR_NAME"
+      "github": "INSERT_YOUR_GITHUB_USERNAME"
     }
   ],
   "repository": [


### PR DESCRIPTION
It's common for a new user's first publish to fail and they receive no notification. This happens when they use release automation and the release author is the github-actions bot, so we can't attribute the release event to a user with an email.

This improves the chances that someone will receive an email by emailing errors to everyone in the maintainers list in the bcr entry's metadata.json file. It also makes maintainers aware of releases by tagging them in the PR body.

Related to https://github.com/bazel-contrib/publish-to-bcr/issues/59