### PR TITLE
refactor: richly model metadata file

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,64 @@
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toThrowErrorContaining<T extends Error>(
+        errorType: new (...args: any[]) => T,
+        message: string
+      ): R;
+    }
+  }
+}
+
+expect.extend({
+  toThrowErrorContaining<T extends Error>(
+    func: Function,
+    errorType: new (...args: any[]) => T,
+    message: string
+  ) {
+    try {
+      func();
+    } catch (e) {
+      if (!(e instanceof errorType)) {
+        return {
+          pass: false,
+          message: () => `\
+Expected error to throw:
+
+    ${errorType}
+
+But instead it threw:
+
+    ${e.constructor}
+`,
+        };
+      }
+
+      if (!e.message.includes(message)) {
+        return {
+          pass: false,
+          message: () => `\
+Expected error message to contain:
+
+    ${message}
+
+But instead it was:
+
+    ${e.message}
+`,
+        };
+      }
+
+      return {
+        pass: true,
+        message: () => "",
+      };
+    }
+
+    return {
+      pass: false,
+      message: () => "Expected function to throw but it did not",
+    };
+  },
+});
+
+export default undefined;

--- a/src/domain/metadata-file.spec.ts
+++ b/src/domain/metadata-file.spec.ts
@@ -1,0 +1,335 @@
+import { mocked } from "jest-mock";
+import fs from "node:fs";
+import "../../jest.setup";
+import { MetadataFile, MetadataFileError } from "./metadata-file";
+
+jest.mock("node:fs");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function mockMetadataFile(content: string) {
+  mocked(fs.readFileSync).mockReturnValue(content);
+}
+
+describe("constructor", () => {
+  test("complains if the metadata file does not exist", () => {
+    mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("Error: ENOENT: no such file or directory");
+    });
+
+    expect(() => new MetadataFile("metadata.json")).toThrow(MetadataFileError);
+  });
+
+  test("complains if the metadata file has invalid json", () => {
+    mockMetadataFile(`\
+{
+    "homepage: "https://foo.bar"
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrow(MetadataFileError);
+  });
+
+  test("complains if the 'versions' field is missing'", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [
+        {
+            "email": "json@aspect.dev",
+            "github": "json",
+            "name": "Jason Bearded"
+        }
+    ],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "yanked_versions": {}
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrowErrorContaining(
+      MetadataFileError,
+      "versions"
+    );
+  });
+
+  test("complains if the 'versions' field not an array'", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [
+        {
+            "email": "json@aspect.dev",
+            "github": "json",
+            "name": "Jason Bearded"
+        }
+    ],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": {},
+    "yanked_versions": {}
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrowErrorContaining(
+      MetadataFileError,
+      "versions"
+    );
+  });
+
+  test("complains if the 'versions' field contains a non-string'", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [
+        {
+            "email": "json@aspect.dev",
+            "github": "json",
+            "name": "Jason Bearded"
+        }
+    ],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": ["1", 2, "3"],
+    "yanked_versions": {}
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrowErrorContaining(
+      MetadataFileError,
+      "versions"
+    );
+  });
+
+  test("complains if the 'yanked_versions' field is missing'", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [
+        {
+            "email": "json@aspect.dev",
+            "github": "json",
+            "name": "Jason Bearded"
+        }
+    ],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": []
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrowErrorContaining(
+      MetadataFileError,
+      "yanked_versions"
+    );
+  });
+
+  test("complains if the 'yanked_versions' field is not an object'", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [
+        {
+            "email": "json@aspect.dev",
+            "github": "json",
+            "name": "Jason Bearded"
+        }
+    ],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": []
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrowErrorContaining(
+      MetadataFileError,
+      "yanked_versions"
+    );
+  });
+
+  test("complains if a 'yanked_versions' entry contains a non-string'", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [
+        {
+            "email": "json@aspect.dev",
+            "github": "json",
+            "name": "Jason Bearded"
+        }
+    ],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {
+        "1.2.3": 42
+    }
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrowErrorContaining(
+      MetadataFileError,
+      "yanked_versions"
+    );
+  });
+
+  test("succeeds if the 'maintainers' field is missing'", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+`);
+    const metadata = new MetadataFile("metadata.json");
+    expect(metadata.maintainers.length).toEqual(0);
+  });
+
+  test("succeeds if the list of maintainers is empty'", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+`);
+    const metadata = new MetadataFile("metadata.json");
+    expect(metadata.maintainers.length).toEqual(0);
+  });
+
+  test("fails if 'maintainers' is not a list", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": {},
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrowErrorContaining(
+      MetadataFileError,
+      "maintainers"
+    );
+  });
+
+  test("fails if 'maintainers' contains non-objects", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [42],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+`);
+    expect(() => new MetadataFile("metadata.json")).toThrowErrorContaining(
+      MetadataFileError,
+      "maintainers"
+    );
+  });
+
+  test("succeeds if maintainer doesn't have an email", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [{
+        "name": "Json Bearded",
+        "github": "jbedard"
+    }],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+`);
+    const metadata = new MetadataFile("metadata.json");
+    expect(metadata.maintainers[0].name).toEqual("Json Bearded");
+    expect(metadata.maintainers[0].github).toEqual("jbedard");
+    expect(metadata.maintainers[0].email).toBeUndefined();
+  });
+
+  test("succeeds if maintainer doesn't have a github handle", () => {
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [{
+        "name": "Json Bearded",
+        "email": "json@bearded.ca"
+    }],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}
+`);
+    const metadata = new MetadataFile("metadata.json");
+    expect(metadata.maintainers[0].name).toEqual("Json Bearded");
+    expect(metadata.maintainers[0].email).toEqual("json@bearded.ca");
+    expect(metadata.maintainers[0].github).toBeUndefined();
+  });
+});
+
+describe("save", () => {
+  test("preserves fields that the app doesn't care about", () => {
+    mockMetadataFile(`\
+        {
+            "homepage": "https://foo.bar",
+            "maintainers": [{
+                "name": "Json Bearded",
+                "email": "json@bearded.ca"
+            }],
+            "repository": [
+                "github:bar/rules_foo"
+            ],
+            "versions": [],
+            "yanked_versions": {}
+        }
+        `);
+
+    const metadata = new MetadataFile("metadata.json");
+    metadata.save("metadata.json");
+
+    const written = mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(JSON.parse(written).homepage).toEqual("https://foo.bar");
+  });
+
+  test("preserves maintainer fields that the app doesn't know about", () => {
+    mockMetadataFile(`\
+        {
+            "homepage": "https://foo.bar",
+            "maintainers": [{
+                "name": "Json Bearded",
+                "email": "json@bearded.ca",
+                "disposition": "bearded"
+            }],
+            "repository":   [
+                "github:bar/rules_foo"
+            ],
+            "versions": [],
+            "yanked_versions": {}
+        }
+        `);
+
+    const metadata = new MetadataFile("metadata.json");
+    metadata.save("metadata.json");
+
+    const written = mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(JSON.parse(written).maintainers[0].disposition).toEqual("bearded");
+  });
+});

--- a/src/domain/metadata-file.ts
+++ b/src/domain/metadata-file.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+
+export class MetadataFileError extends Error {
+  constructor(path: string, message: string) {
+    super(`Could not read metadata file at ${path}: ${message}`);
+  }
+}
+
+// Examples: https://docs.google.com/document/d/1moQfNcEIttsk6vYanNKIy3ZuK53hQUFq1b1r0rmsYVg/edit#bookmark=id.1i90c6c14zvx
+// Discussion: https://github.com/bazel-contrib/publish-to-bcr/issues/59#issuecomment-1784979303
+// Name is required, github handle and email are optional.
+export interface Maintainer {
+  name: string;
+  email?: string;
+  github?: string;
+}
+
+export class MetadataFile {
+  private readonly metadata: {
+    versions: string[];
+    yankedVersions: string[];
+  } & any;
+
+  constructor(readonly filepath: string) {
+    let json: any;
+
+    try {
+      json = JSON.parse(fs.readFileSync(filepath, "utf8"));
+    } catch (e) {
+      throw new MetadataFileError(filepath, e.message);
+    }
+
+    if (
+      !("versions" in json) ||
+      !Array.isArray(json.versions) ||
+      !json.versions.every((v: any) => typeof v === "string")
+    ) {
+      throw new MetadataFileError(filepath, "could not parse 'versions'");
+    }
+
+    if (
+      !("yanked_versions" in json) ||
+      typeof json.yanked_versions !== "object" ||
+      Array.isArray(json.yanked_versions) ||
+      !Object.entries(json.yanked_versions).every(
+        ([k, v]) => typeof k === "string" && typeof v === "string"
+      )
+    ) {
+      throw new MetadataFileError(
+        filepath,
+        "could not parse 'yanked_versions'"
+      );
+    }
+
+    if (
+      "maintainers" in json &&
+      (!Array.isArray(json.maintainers) ||
+        !json.maintainers.every((m: any) => typeof m === "object"))
+    ) {
+      throw new MetadataFileError(filepath, "could not parse 'maintainers'");
+    }
+
+    this.metadata = json;
+  }
+
+  public get maintainers(): ReadonlyArray<Maintainer> {
+    return (this.metadata.maintainers || []) as Maintainer[];
+  }
+
+  public get versions(): ReadonlyArray<string> {
+    return this.metadata.versions;
+  }
+
+  public get yankedVersions(): Readonly<{ [version: string]: string }> {
+    return this.metadata.yanked_versions;
+  }
+
+  public clearVersions(): void {
+    this.metadata.versions = [];
+  }
+
+  public clearYankedVersions(): void {
+    this.metadata.yanked_versions = {};
+  }
+
+  public addVersions(...versions: ReadonlyArray<string>): void {
+    this.metadata.versions.push(...versions);
+  }
+
+  public addYankedVersions(yankedVersions: {
+    [version: string]: string;
+  }): void {
+    this.metadata.yanked_versions = {
+      ...this.metadata.yanked_versions,
+      ...yankedVersions,
+    };
+  }
+
+  public hasVersion(version: string): boolean {
+    return this.metadata.versions.includes(version);
+  }
+
+  public save(destPath: string) {
+    fs.writeFileSync(
+      destPath,
+      `${JSON.stringify(this.metadata, undefined, 4)}\n`
+    );
+  }
+}


### PR DESCRIPTION
Prefactor for #75 
Depends on  #76 

Richly models the bcr metadata file so that it's easier to pull out the maintainers.