### PR TITLE
chore: upgrade to node18 runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: yarn test

--- a/deployment/modules/webhook/main.tf
+++ b/deployment/modules/webhook/main.tf
@@ -35,7 +35,7 @@ resource "google_storage_bucket_object" "publish_to_bcr_function_bucket_object" 
 resource "google_cloudfunctions_function" "publish_to_bcr_function" {
   name        = "github-webhook"
   description = "Handle incoming github events"
-  runtime     = "nodejs16"
+  runtime     = "nodejs18"
 
   available_memory_mb   = 512
   source_archive_bucket = google_storage_bucket.source_archive_bucket.name

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "main": "./application/cloudfunction/index.js",
+  "engines": {
+    "node": "^18"
+  },
   "scripts": {
     "prebuild": "node tools/clean-dist-files.js",
     "build": "tsc && node tools/copy-dist-files.js",


### PR DESCRIPTION
Google Cloud Functions is deprecating node16 support in January.