### PR TITLE
fix: fix a bug where a ruleset error results in an unknown error

### DIFF
--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -184,7 +184,10 @@ export class ReleaseEventHandler {
         [error]
       );
 
-      return;
+      return {
+        rulesetRepo: error.repository,
+        successful: false,
+      };
     }
   }
 


### PR DESCRIPTION
Caused by some recent refactoring. This was returning undefined and the error handling code puked when it tried to read the object.