### PR TITLE
Revert "feat: allow BCR maintainers to modify pull request"

### DIFF
--- a/src/infrastructure/github.ts
+++ b/src/infrastructure/github.ts
@@ -86,7 +86,7 @@ export class GitHubClient {
       body,
       head: `${fromRepo.owner}:${fromBranch}`,
       base: toBranch,
-      maintainer_can_modify: true,
+      maintainer_can_modify: false,
     });
 
     return pull.number;


### PR DESCRIPTION
This reverts commit 354ba4e07b1bc75ebebcc7bb1103ab187f5b9753.

Recall there are actually two GitHub apps: one that users install to their ruleset/fork, and one that Google installs on the BCR for opening pull requests. The second app doesn't have repository write permissions so Google is more comfortable installing it to the BCR.

Testing this in my dev environment, it fails because the second GitHub app, which opens up the pull request, doesn't have permissions to the fork it's pr'ing from, so it can't enable this option. To solve this, I think we would need to ask users to install both apps (worse DX) or use one app with elevated permissions (Google doesn't like).