### PR TITLE
fix: be consistently strict when parsing semvers

### DIFF
--- a/src/domain/metadata-file.spec.ts
+++ b/src/domain/metadata-file.spec.ts
@@ -376,6 +376,28 @@ describe("constructor", () => {
 
     expect(metadata.versions).toEqual(["12.4.2.1.1", "20210324.2", "55"]);
   });
+
+  test("sorts non-semver versions that look like semver as non-semver", () => {
+    // https://github.com/bazel-contrib/publish-to-bcr/issues/97
+    mockMetadataFile(`\
+{
+    "homepage": "https://foo.bar",
+    "maintainers": [],
+    "repository": [
+        "github:bar/rules_foo"
+    ],
+    "versions": [
+      "1.0.0-rc0",
+      "1.0.0-rc1",
+      "1.0.0rc1"
+    ],
+    "yanked_versions": {}
+}
+`);
+    const metadata = new MetadataFile("metadata.json");
+
+    expect(metadata.versions).toEqual(["1.0.0rc1", "1.0.0-rc0", "1.0.0-rc1"]);
+  });
 });
 
 describe("save", () => {

--- a/src/domain/metadata-file.ts
+++ b/src/domain/metadata-file.ts
@@ -137,14 +137,18 @@ export class MetadataFile {
   }
 
   private sortVersions(): void {
-    const semver = this.metadata.versions.filter(validSemver);
+    const semver = this.metadata.versions.filter(
+      (v: string) => !!validSemver(v, { loose: false })
+    );
     const nonSemver = this.metadata.versions.filter(
       (v: string) => !validSemver(v)
     );
 
     this.metadata.versions = [
       ...nonSemver.sort(),
-      ...semver.sort(semverCompare),
+      ...semver.sort((a: string, b: string) =>
+        semverCompare(a, b, { loose: false })
+      ),
     ];
   }
 }


### PR DESCRIPTION
The issue was that `validSemver` defaults loose parsing while `semverCompare` defaults to strict parsing. The comparison method was being passed an invalid semver and threw.

Closes https://github.com/bazel-contrib/publish-to-bcr/issues/97.