### PR TITLE
fix: correctly fetch gcp project id

### DIFF
--- a/e2e/stubs/cloud-functions.ts
+++ b/e2e/stubs/cloud-functions.ts
@@ -38,7 +38,6 @@ export class CloudFunctions implements StubbedServer {
           SMTP_HOST: this.emailAccount.smtp.host,
           SMTP_PORT: this.emailAccount.smtp.port.toString(),
           NOTIFICATIONS_EMAIL: this.emailAccount.user,
-          GCP_PROJECT: "test-project",
           SECRET_MANAGER_HOST: this.secrets.getHost(),
           SECRET_MANAGER_PORT: this.secrets.getPort().toString(),
           BAZEL_CENTRAL_REGISTRY: "bazelbuild/bazel-central-registry",


### PR DESCRIPTION
This regressed [here](https://github.com/bazel-contrib/publish-to-bcr/pull/102/files#diff-ea429e183d271a16af993f4c620905c6d071c4062ba83288bbe1b91b2a41a480R21-L21). I had read some outdated docs that said the project id was exposed as an environment variable, but this is only true for older runtimes.