### PR TITLE
fix: properly attribute the github-actions[bot] as a commit author

### DIFF
--- a/e2e/helpers/fixture.ts
+++ b/e2e/helpers/fixture.ts
@@ -31,7 +31,7 @@ export enum Fixture {
 export async function setupLocalRemoteRulesetRepo(
   fixture: Fixture,
   tag: string,
-  releaser: Partial<User>
+  commitAuthor: Partial<User>
 ): Promise<void> {
   const gitRepoPath = path.join(PREPARED_FIXTURES_PATH, fixture);
   let git: SimpleGit;
@@ -44,8 +44,8 @@ export async function setupLocalRemoteRulesetRepo(
     git = simpleGit(gitRepoPath);
     await git.init();
     await git.add("./*");
-    await git.addConfig("user.name", releaser.login!);
-    await git.addConfig("user.email", releaser.email!);
+    await git.addConfig("user.name", commitAuthor.login!);
+    await git.addConfig("user.email", commitAuthor.email!);
     await git.commit("first commit");
   } else {
     git = simpleGit(gitRepoPath);

--- a/e2e/stubs/fake-github.ts
+++ b/e2e/stubs/fake-github.ts
@@ -202,7 +202,7 @@ export class FakeGitHub implements StubbedServer {
     const pattern = /\/users\/([^/]+)\/repos/;
     await this.server.forGet(pattern).thenCallback((request) => {
       const match = request.path.match(pattern);
-      const owner = match![1];
+      const owner = decodeURIComponent(match![1]);
 
       if (this.ownedRepos.has(owner)) {
         return {


### PR DESCRIPTION
When the release author is the `github-actions[bot]` and a fixedReleaser isn't set, the author of the commit in the BCR PR doesn't render well. Example: https://github.com/bazelbuild/bazel-central-registry/pull/1195/commits/051881937d9d730082bfb18357522d791968d746.

The properly sets the correct author info for the bot for GitHub to render it correctly.

Closes https://github.com/bazel-contrib/publish-to-bcr/issues/82.