### PR TITLE
Update README with error log info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Prepare your ruleset for bzlmod by following the [Bzlmod User Guide](https://baz
    _Note: Authors of rulesets under the `bazelbuild` org should add the app to their personal fork of `bazelbuild/bazel-central-registry`._
 
 1. Include these [template files](./templates) in your ruleset repository.
-1. Cut a release. You will be tagged in a pull request against the BCR.
+1. Cut a release.
+    * If successful, you will discover a branch in your fork of the BCR and you will be tagged in a pull request against the actual BCR.
+    * If unsuccessful, check your email for error logs.
 
 ## A note on release automation
 


### PR DESCRIPTION
Direct users to where they can find error logs when things go wrong (as they invariably will on a first attempt).

It took me a solid 20 minutes to discover any sign that the app had tried to run and it seems that this is a fairly common question in bazel's slack. This should help people in the future.