### PR TITLE
Update template URL to a stable URL

### DIFF
--- a/templates/.bcr/source.template.json
+++ b/templates/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
 }

--- a/templates/README.md
+++ b/templates/README.md
@@ -77,7 +77,7 @@ The `integrity` hash will automatically be filled out by the app.
 {
   "integrity": "", // <-- Leave this alone
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
 }
 ```
 


### PR DESCRIPTION
BCR appears to enforce this now