### PR TITLE
ci: don't run e2es on PRs from forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,10 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # Don't run e2es on PRs from forks as it requires access to secrets
+    # when using `pull_request`.
+    # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests
+    if: ${{ github.event.pull_request.head.repo.full_name == 'bazel-contrib/publish-to-bcr' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
E2es fail on pull requests from a fork because GitHub Actions doesn't allow access to secrets on the `pull_request` trigger. `pull_request_target ` is supposed to allow this. I added the label `run e2e` to tag PRs to allow e2es to be run, the assumption being that we carefully look through the changes before tagging. In addition, outside contributions must be approved.