### PR TITLE
refactor: decouple github auth from api calls

### DIFF
--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -106,7 +106,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseTarball(repo, "unversioned-1.0.0");
@@ -118,6 +118,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -144,7 +145,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseTarball(repo, "versioned-1.0.0");
@@ -156,6 +157,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -183,7 +185,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseTarball(repo, "tarball-1.0.0");
@@ -195,6 +197,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -222,7 +225,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseZip(repo, "zip-1.0.0");
@@ -234,6 +237,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -261,7 +265,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseTarball(repo);
@@ -273,6 +277,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -300,7 +305,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseTarball(repo);
@@ -312,6 +317,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -327,12 +333,6 @@ describe("e2e tests", () => {
   });
 
   test("happy path", async () => {
-    // This test checks for authentication token requests which may be cached.
-    // Restart the cloud functions server to ensure a consistently uncached
-    // state for this test.
-    await cloudFunctions.shutdown();
-    await cloudFunctions.start();
-
     const repo = Fixture.Versioned;
     const tag = "v1.0.0";
     await setupLocalRemoteRulesetRepo(repo, tag, releaser);
@@ -357,6 +357,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      rulesetInstallationId,
       {
         owner: testOrg,
         repo,
@@ -422,7 +423,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive1 = await makeReleaseTarball(repo, "module-1.0.0");
@@ -441,6 +442,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -510,7 +512,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseTarball(
@@ -525,6 +527,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -556,7 +559,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(releaser.login!, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseTarball(repo, "versioned-1.0.0");
@@ -568,6 +571,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -605,7 +609,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     // App not installed to fork
     // fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
@@ -618,6 +622,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,
@@ -652,7 +657,7 @@ describe("e2e tests", () => {
       "bazelbuild",
       "bazel-central-registry"
     );
-    fakeGitHub.mockAppInstallation(testOrg, repo);
+    const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
     const releaseArchive = await makeReleaseTarball(repo, "versioned-1.0.0");
@@ -664,6 +669,7 @@ describe("e2e tests", () => {
     const response = await publishReleaseEvent(
       cloudFunctions.getBaseUrl(),
       secrets.webhookSecret,
+      installationId,
       {
         owner: testOrg,
         repo,

--- a/e2e/helpers/webhook.ts
+++ b/e2e/helpers/webhook.ts
@@ -7,6 +7,7 @@ import type { DeepPartial } from "./types";
 export async function publishReleaseEvent(
   webhookUrl: string,
   webhookSecret: string,
+  installationId: number,
   release: { owner: string; repo: string; tag: string; releaser: Partial<User> }
 ): Promise<AxiosResponse> {
   const body: DeepPartial<ReleasePublishedEvent> = {
@@ -21,6 +22,9 @@ export async function publishReleaseEvent(
     release: {
       html_url: `https://github.com/${release.owner}/${release.repo}/releases/tag/${release.tag}`,
       tag_name: release.tag,
+    },
+    installation: {
+      id: installationId,
     },
   };
 

--- a/e2e/stubs/fake-github.ts
+++ b/e2e/stubs/fake-github.ts
@@ -1,5 +1,5 @@
 import { User } from "@octokit/webhooks-types";
-import { randomInt, randomUUID } from "crypto";
+import { randomUUID } from "crypto";
 import * as mockttp from "mockttp";
 import url from "node:url";
 import { StubbedServer } from "./stubbed-server";
@@ -74,14 +74,15 @@ export class FakeGitHub implements StubbedServer {
     this.repositories.clear();
   }
 
+  private nextInstallationId = 1;
   public mockAppInstallation(owner: string, repo: string): number {
-    const installationId = randomInt(50000);
+    const installationId = this.nextInstallationId++;
     this.appInstallations.set(`${owner}/${repo}`, installationId);
     return installationId;
   }
 
   public mockBotAppInstallation(owner: string, repo: string): number {
-    const installationId = randomInt(50000);
+    const installationId = this.nextInstallationId++;
     this.botAppInstallations.set(`${owner}/${repo}`, installationId);
     return installationId;
   }

--- a/src/application/cloudfunction/github-webhook-entrypoint.ts
+++ b/src/application/cloudfunction/github-webhook-entrypoint.ts
@@ -1,39 +1,7 @@
 import { HttpFunction } from "@google-cloud/functions-framework";
 import { Webhooks } from "@octokit/webhooks";
-import { CreateEntryService } from "../../domain/create-entry.js";
-import { FindRegistryForkService } from "../../domain/find-registry-fork.js";
-import { PublishEntryService } from "../../domain/publish-entry.js";
-import { Repository } from "../../domain/repository.js";
-import { EmailClient } from "../../infrastructure/email.js";
-import { GitClient } from "../../infrastructure/git.js";
-import { GitHubClient } from "../../infrastructure/github.js";
 import { SecretsClient } from "../../infrastructure/secrets.js";
-import { NotificationsService } from "../notifications.js";
 import { ReleaseEventHandler } from "../release-event-handler.js";
-
-// Setup application dependencies using constructor dependency injection.
-const secretsClient = new SecretsClient();
-const gitClient = new GitClient();
-const githubClient = new GitHubClient();
-const emailClient = new EmailClient();
-const findRegistryForkService = new FindRegistryForkService(githubClient);
-const createEntryService = new CreateEntryService(gitClient, githubClient);
-const publishEntryService = new PublishEntryService(githubClient);
-const notificationsService = new NotificationsService(
-  emailClient,
-  secretsClient,
-  githubClient
-);
-
-const releaseEventHandler = new ReleaseEventHandler(
-  githubClient,
-  secretsClient,
-  findRegistryForkService,
-  createEntryService,
-  publishEntryService,
-  notificationsService
-);
-Repository.gitClient = gitClient;
 
 // Handle incoming GitHub webhook messages. This is the entrypoint for
 // the webhook cloud function.
@@ -41,6 +9,11 @@ export const handleGithubWebhookEvent: HttpFunction = async (
   request,
   response
 ) => {
+  // Setup application dependencies using constructor dependency injection.
+  const secretsClient = new SecretsClient();
+
+  const releaseEventHandler = new ReleaseEventHandler(secretsClient);
+
   const githubWebhookSecret = await secretsClient.accessSecret(
     "github-app-webhook-secret"
   );

--- a/src/application/octokit.ts
+++ b/src/application/octokit.ts
@@ -1,0 +1,41 @@
+import { Octokit } from "@octokit/rest";
+import { getAppAuthorizedOctokit } from "../infrastructure/github.js";
+import { SecretsClient } from "../infrastructure/secrets.js";
+
+export async function createAppAuthorizedOctokit(
+  secretsClient: SecretsClient
+): Promise<Octokit> {
+  const [githubAppPrivateKey, githubAppClientId, githubAppClientSecret] =
+    await Promise.all([
+      secretsClient.accessSecret("github-app-private-key"),
+      secretsClient.accessSecret("github-app-client-id"),
+      secretsClient.accessSecret("github-app-client-secret"),
+    ]);
+
+  return getAppAuthorizedOctokit(
+    Number(process.env.GITHUB_APP_ID),
+    githubAppPrivateKey,
+    githubAppClientId,
+    githubAppClientSecret
+  );
+}
+
+export async function createBotAppAuthorizedOctokit(
+  secretsClient: SecretsClient
+): Promise<Octokit> {
+  const [
+    githubBotAppPrivateKey,
+    githubBotAppClientId,
+    githubBotAppClientSecret,
+  ] = await Promise.all([
+    secretsClient.accessSecret("github-bot-app-private-key"),
+    secretsClient.accessSecret("github-bot-app-client-id"),
+    secretsClient.accessSecret("github-bot-app-client-secret"),
+  ]);
+  return getAppAuthorizedOctokit(
+    Number(process.env.GITHUB_BOT_APP_ID),
+    githubBotAppPrivateKey,
+    githubBotAppClientId,
+    githubBotAppClientSecret
+  );
+}

--- a/src/domain/create-entry.spec.ts
+++ b/src/domain/create-entry.spec.ts
@@ -88,7 +88,7 @@ beforeEach(() => {
   });
 
   mockGitClient = mocked(new GitClient());
-  mockGithubClient = mocked(new GitHubClient());
+  mockGithubClient = mocked(new GitHubClient({} as any));
   mocked(computeIntegrityHash).mockReturnValue(`sha256-${randomUUID()}`);
   Repository.gitClient = mockGitClient;
   createEntryService = new CreateEntryService(mockGitClient, mockGithubClient);

--- a/src/domain/find-registry-fork.spec.ts
+++ b/src/domain/find-registry-fork.spec.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
   mocked(GitHubClient, true).mockClear();
   mockRulesetRepoCreate.mockClear();
 
-  mockGithubClient = mocked(new GitHubClient());
+  mockGithubClient = mocked(new GitHubClient({} as any));
   findRegistryForkService = new FindRegistryForkService(mockGithubClient);
 });
 

--- a/src/domain/publish-entry.spec.ts
+++ b/src/domain/publish-entry.spec.ts
@@ -9,7 +9,7 @@ let publishEntryService: PublishEntryService;
 let mockGithubClient: Mocked<GitHubClient>;
 beforeEach(() => {
   mocked(GitHubClient, true).mockClear();
-  mockGithubClient = mocked(new GitHubClient());
+  mockGithubClient = mocked(new GitHubClient({} as any));
   publishEntryService = new PublishEntryService(mockGithubClient);
 });
 


### PR DESCRIPTION
Prefactor for #120.

I had an awkward coupling between how the github client (octokit) is authorized and the api calls it can make, when really they should be separate. There are several different ways we need to authorize: as one of the two GitHub apps, as an installation of those apps on the ruleset repo, bcr fork, and canonical bcr. This decoupling will help me fix #120 in a clean way.