### PR TITLE
feat: use app bot as commit author in place of github-actions bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,16 @@ Prepare your ruleset for bzlmod by following the [Bzlmod User Guide](https://baz
 
 ## How it works
 
-1. [Configure](https://github.com/apps/publish-to-bcr) the app for:
+1. [Configure](https://github.com/apps/publish-to-bcr) the app for two repositories:
 
    - Your ruleset repository.
-   - A fork of [bazelbuild/bazel-central-registry](https://github.com/bazelbuild/bazel-central-registry). The fork can be in the same GitHub account as your ruleset _or_ in the release author's personal account.
+   - A fork of [bazelbuild/bazel-central-registry](https://github.com/bazelbuild/bazel-central-registry). The fork can be in the same GitHub account as your ruleset _or_ in the release author's personal account. If you use release automation and the release author is the github-actions bot, then the fork must
+     be in ruleset's account unless you [override the releaser](./templates/README.md#optional-configyml).
 
    _Note: Authors of rulesets under the `bazelbuild` org should add the app to their personal fork of `bazelbuild/bazel-central-registry`._
 
 1. Include these [template files](./templates) in your ruleset repository.
 1. Cut a release. You will be tagged in a pull request against the BCR.
-
-## A note on release automation
-
-Publish to BCR uses information about the GitHub author of a release in order to tag that author in the commit, push an entry to their BCR fork, or send error notifications. If you use a GitHub action to automate your release and the author is the `github-actions` bot (likely because you used the `GITHUB_TOKEN` secret to authorize the action), then the app won't know who cut the release and may not function properly.
-
-You can work around this by setting a [fixed releaser](./templates/README.md#optional-configyml).
 
 ## Publishing multiple modules in the same repo
 

--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -127,7 +127,8 @@ export class ReleaseEventHandler {
             );
             const createEntryService = new CreateEntryService(
               gitClient,
-              forkGitHubClient
+              forkGitHubClient,
+              bcrGitHubClient
             );
 
             const attempt = await this.attemptPublish(

--- a/src/domain/user.ts
+++ b/src/domain/user.ts
@@ -1,4 +1,5 @@
 export interface User {
+  readonly id?: number;
   readonly name?: string;
   readonly username: string;
   readonly email: string;


### PR DESCRIPTION
When the release author is the `github-actions` bot, attribute the entry commit to the `publish-to-bcr-bot` to avoid CLA issues on the BCR. The bot has already "signed" the CLI in order to open up the PRs.

Closes #120 