### PR TITLE
Cope with missing `version` attribute on module

### DIFF
--- a/e2e/__snapshots__/e2e.spec.ts.snap
+++ b/e2e/__snapshots__/e2e.spec.ts.snap
@@ -168,7 +168,10 @@ exports[`e2e tests [snapshot] ruleset with unversioned module in source 1`] = `
 "----------------------------------------------------
 modules/unversioned/1.0.0/MODULE.bazel
 ----------------------------------------------------
-module(name = \\"unversioned\\", version = \\"1.0.0\\")
+module(
+    name = \\"unversioned\\",
+  version = \\"1.0.0\\"
+)
 
 ----------------------------------------------------
 modules/unversioned/1.0.0/patches/module_dot_bazel_version.patch
@@ -176,9 +179,12 @@ modules/unversioned/1.0.0/patches/module_dot_bazel_version.patch
 ===================================================================
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -1,1 +1,1 @@
--module(name = \\"unversioned\\")
-+module(name = \\"unversioned\\", version = \\"1.0.0\\")
+@@ -1,3 +1,4 @@
+ module(
+-    name = \\"unversioned\\"
++    name = \\"unversioned\\",
++  version = \\"1.0.0\\"
+ )
 
 ----------------------------------------------------
 modules/unversioned/1.0.0/presubmit.yml
@@ -198,11 +204,11 @@ bcr_test_module:
 modules/unversioned/1.0.0/source.json
 ----------------------------------------------------
 {
-    \\"integrity\\": \\"sha256-X2ZIYATg3qceheFSj/qaTU0SqqW/hFc8UIGkrK3FmZQ=\\",
+    \\"integrity\\": \\"sha256-oLg/mgWyhr6DFepRYkjoPphQ8KOriLgu6M4x2RSsLbU=\\",
     \\"strip_prefix\\": \\"unversioned-1.0.0\\",
     \\"url\\": \\"https://github.com/testorg/unversioned/archive/refs/tags/v1.0.0.tar.gz\\",
     \\"patches\\": {
-        \\"module_dot_bazel_version.patch\\": \\"sha256-OoXz9ahBlGjW4IVb4QCmXMZInK7XbFEjCHya3wx8AAk=\\"
+        \\"module_dot_bazel_version.patch\\": \\"sha256-CahdP4+xcGJVM9GyA0Sg2rUe5rIPHzKJ6J4SfFTm2x8=\\"
     },
     \\"patch_strip\\": 1
 }
@@ -326,7 +332,7 @@ bcr_test_module:
 modules/zero-versioned/1.0.0/source.json
 ----------------------------------------------------
 {
-    \\"integrity\\": \\"sha256-P4olS5x2mo1PJPI6iU0TMfPHWs9inbRZFJZHmhEY4no=\\",
+    \\"integrity\\": \\"sha256-sLh05DKTEOuO3vz9+IDUJJNOf0GSLxdGDJ8qOLZRUCQ=\\",
     \\"strip_prefix\\": \\"zero-versioned-1.0.0\\",
     \\"url\\": \\"https://github.com/testorg/zero-versioned/archive/refs/tags/v1.0.0.tar.gz\\",
     \\"patches\\": {

--- a/e2e/__snapshots__/e2e.spec.ts.snap
+++ b/e2e/__snapshots__/e2e.spec.ts.snap
@@ -170,7 +170,7 @@ modules/unversioned/1.0.0/MODULE.bazel
 ----------------------------------------------------
 module(
     name = \\"unversioned\\",
-  version = \\"1.0.0\\"
+  version = \\"1.0.0\\",
 )
 
 ----------------------------------------------------
@@ -183,7 +183,7 @@ modules/unversioned/1.0.0/patches/module_dot_bazel_version.patch
  module(
 -    name = \\"unversioned\\"
 +    name = \\"unversioned\\",
-+  version = \\"1.0.0\\"
++  version = \\"1.0.0\\",
  )
 
 ----------------------------------------------------
@@ -208,7 +208,7 @@ modules/unversioned/1.0.0/source.json
     \\"strip_prefix\\": \\"unversioned-1.0.0\\",
     \\"url\\": \\"https://github.com/testorg/unversioned/archive/refs/tags/v1.0.0.tar.gz\\",
     \\"patches\\": {
-        \\"module_dot_bazel_version.patch\\": \\"sha256-CahdP4+xcGJVM9GyA0Sg2rUe5rIPHzKJ6J4SfFTm2x8=\\"
+        \\"module_dot_bazel_version.patch\\": \\"sha256-LGXyh9FLhgIPbe0gHfxAPnEQ7HVR+HUP/IDbPdl3ZkA=\\"
     },
     \\"patch_strip\\": 1
 }

--- a/e2e/__snapshots__/e2e.spec.ts.snap
+++ b/e2e/__snapshots__/e2e.spec.ts.snap
@@ -286,6 +286,79 @@ modules/versioned/metadata.json
 "
 `;
 
+exports[`e2e tests [snapshot] ruleset with zero-versioned module in source 1`] = `
+"----------------------------------------------------
+modules/zero-versioned/1.0.0/MODULE.bazel
+----------------------------------------------------
+module(
+    name = \\"zero-versioned\\",
+    version = \\"1.0.0\\",
+)
+
+----------------------------------------------------
+modules/zero-versioned/1.0.0/patches/module_dot_bazel_version.patch
+----------------------------------------------------
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,4 +1,4 @@
+ module(
+     name = \\"zero-versioned\\",
+-    version = \\"0.0.0\\",
++    version = \\"1.0.0\\",
+ )
+
+----------------------------------------------------
+modules/zero-versioned/1.0.0/presubmit.yml
+----------------------------------------------------
+bcr_test_module:
+  module_path: \\"e2e/bzlmod\\"
+  matrix:
+    platform: [\\"debian10\\", \\"macos\\", \\"ubuntu2004\\", \\"windows\\"]
+  tasks:
+    run_tests:
+      name: \\"Run test module\\"
+      platform: \${{ platform }}
+      test_targets:
+        - \\"//...\\"
+
+----------------------------------------------------
+modules/zero-versioned/1.0.0/source.json
+----------------------------------------------------
+{
+    \\"integrity\\": \\"sha256-P4olS5x2mo1PJPI6iU0TMfPHWs9inbRZFJZHmhEY4no=\\",
+    \\"strip_prefix\\": \\"zero-versioned-1.0.0\\",
+    \\"url\\": \\"https://github.com/testorg/zero-versioned/archive/refs/tags/v1.0.0.tar.gz\\",
+    \\"patches\\": {
+        \\"module_dot_bazel_version.patch\\": \\"sha256-KpbuC1vv5mfhdTs5nnTl3/pH7Y/6JCnD1b1XLsqyOAo=\\"
+    },
+    \\"patch_strip\\": 1
+}
+
+----------------------------------------------------
+modules/zero-versioned/metadata.json
+----------------------------------------------------
+{
+    \\"homepage\\": \\"https://github.com/testorg/zero-versioned\\",
+    \\"maintainers\\": [
+        {
+            \\"name\\": \\"Foo McBar\\",
+            \\"email\\": \\"foo@test.org\\",
+            \\"github\\": \\"foobar\\"
+        }
+    ],
+    \\"repository\\": [
+        \\"github:testorg/zero-versioned\\"
+    ],
+    \\"versions\\": [
+        \\"1.0.0\\"
+    ],
+    \\"yanked_versions\\": {}
+}
+
+"
+`;
+
 exports[`e2e tests [snapshot] ruleset with zip release archive 1`] = `
 "----------------------------------------------------
 modules/zip/1.0.0/MODULE.bazel

--- a/e2e/__snapshots__/e2e.spec.ts.snap
+++ b/e2e/__snapshots__/e2e.spec.ts.snap
@@ -168,23 +168,17 @@ exports[`e2e tests [snapshot] ruleset with unversioned module in source 1`] = `
 "----------------------------------------------------
 modules/unversioned/1.0.0/MODULE.bazel
 ----------------------------------------------------
-module(
-    name = \\"unversioned\\",
-    version = \\"1.0.0\\",
-)
+module(name = \\"unversioned\\", version = \\"1.0.0\\")
+
 ----------------------------------------------------
 modules/unversioned/1.0.0/patches/module_dot_bazel_version.patch
 ----------------------------------------------------
 ===================================================================
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -1,4 +1,4 @@
- module(
-     name = \\"unversioned\\",
--    version = \\"0.0.0\\",
-+    version = \\"1.0.0\\",
- )
-\\\\ No newline at end of file
+@@ -1,1 +1,1 @@
+-module(name = \\"unversioned\\")
++module(name = \\"unversioned\\", version = \\"1.0.0\\")
 
 ----------------------------------------------------
 modules/unversioned/1.0.0/presubmit.yml
@@ -204,11 +198,11 @@ bcr_test_module:
 modules/unversioned/1.0.0/source.json
 ----------------------------------------------------
 {
-    \\"integrity\\": \\"sha256-eXQOU+DNwg/Q29tX59jP0+SFLvRHrQf3z+KJVS/gIRk=\\",
+    \\"integrity\\": \\"sha256-X2ZIYATg3qceheFSj/qaTU0SqqW/hFc8UIGkrK3FmZQ=\\",
     \\"strip_prefix\\": \\"unversioned-1.0.0\\",
     \\"url\\": \\"https://github.com/testorg/unversioned/archive/refs/tags/v1.0.0.tar.gz\\",
     \\"patches\\": {
-        \\"module_dot_bazel_version.patch\\": \\"sha256-y0kC8heeH9bQKhrfx2JuX+RK0KyjwHhPac3wBc4Nkg4=\\"
+        \\"module_dot_bazel_version.patch\\": \\"sha256-OoXz9ahBlGjW4IVb4QCmXMZInK7XbFEjCHya3wx8AAk=\\"
     },
     \\"patch_strip\\": 1
 }

--- a/e2e/fixtures/unversioned/MODULE.bazel
+++ b/e2e/fixtures/unversioned/MODULE.bazel
@@ -1,1 +1,3 @@
-module(name = "unversioned")
+module(
+    name = "unversioned"
+)

--- a/e2e/fixtures/unversioned/MODULE.bazel
+++ b/e2e/fixtures/unversioned/MODULE.bazel
@@ -1,4 +1,1 @@
-module(
-    name = "unversioned",
-    version = "0.0.0",
-)
+module(name = "unversioned")

--- a/e2e/fixtures/unversioned/README.md
+++ b/e2e/fixtures/unversioned/README.md
@@ -1,1 +1,1 @@
-Ruleset repo that doesn't update the source MODULE.bazel's `version` field.
+Ruleset repo that doesn't have the source MODULE.bazel's `version` field.

--- a/e2e/fixtures/zero-versioned/.bcr/metadata.template.json
+++ b/e2e/fixtures/zero-versioned/.bcr/metadata.template.json
@@ -1,0 +1,15 @@
+{
+  "homepage": "https://github.com/testorg/zero-versioned",
+  "maintainers": [
+    {
+      "name": "Foo McBar",
+      "email": "foo@test.org",
+      "github": "foobar"
+    }
+  ],
+  "repository": [
+    "github:testorg/zero-versioned"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/e2e/fixtures/zero-versioned/.bcr/presubmit.yml
+++ b/e2e/fixtures/zero-versioned/.bcr/presubmit.yml
@@ -1,0 +1,10 @@
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/e2e/fixtures/zero-versioned/.bcr/source.template.json
+++ b/e2e/fixtures/zero-versioned/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}

--- a/e2e/fixtures/zero-versioned/MODULE.bazel
+++ b/e2e/fixtures/zero-versioned/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "zero-versioned",
+    version = "0.0.0",
+)

--- a/e2e/fixtures/zero-versioned/README.md
+++ b/e2e/fixtures/zero-versioned/README.md
@@ -1,1 +1,1 @@
-Ruleset repo that doesn't update the source MODULE.bazel's `version` field.
+Ruleset repo that doesn't set the source MODULE.bazel's `version` field.

--- a/e2e/fixtures/zero-versioned/README.md
+++ b/e2e/fixtures/zero-versioned/README.md
@@ -1,0 +1,1 @@
+Ruleset repo that doesn't update the source MODULE.bazel's `version` field.

--- a/e2e/helpers/fixture.ts
+++ b/e2e/helpers/fixture.ts
@@ -16,6 +16,7 @@ export enum Fixture {
   NoPrefix = "no-prefix",
   Tarball = "tarball",
   Unversioned = "unversioned",
+  ZeroVersioned = "zero-versioned",
   Versioned = "versioned",
   Zip = "zip",
 }

--- a/src/domain/create-entry.ts
+++ b/src/domain/create-entry.ts
@@ -231,7 +231,8 @@ export class CreateEntryService {
   ): void {
     if (moduleFile.version !== version) {
       console.log(
-        "Archived MODULE.bazel version does not match release version. Creating a version patch."
+        `Archived MODULE.bazel version ${moduleFile.version} does not match release version ${version}.`,
+        "Creating a version patch.",
       );
       const patchFileName = "module_dot_bazel_version.patch";
       const existingContent = moduleFile.content;

--- a/src/domain/module-file.spec.ts
+++ b/src/domain/module-file.spec.ts
@@ -80,7 +80,24 @@ module(
     expect(moduleFile.content).toEqual(`\
 module(
   name = "rules_foo",
-  version = "4.5.6"
+  version = "4.5.6",
+)`);
+  });
+
+  test("stamps the version when the version field was originally missing and the last field is comma-trailed", () => {
+    mocked(fs.readFileSync).mockReturnValue(`\
+module(
+  name = "rules_foo",
+  compatibility_level = 1,
+)`);
+    const moduleFile = new ModuleFile("MODULE.bazel");
+    moduleFile.stampVersion("4.5.6");
+
+    expect(moduleFile.content).toEqual(`\
+module(
+  name = "rules_foo",
+  compatibility_level = 1,
+  version = "4.5.6",
 )`);
   });
 });

--- a/src/domain/module-file.spec.ts
+++ b/src/domain/module-file.spec.ts
@@ -36,10 +36,18 @@ describe("moduleName", () => {
   });
 });
 
-describe("moduleVersion", () => {
+describe("version", () => {
   test("parses module version", () => {
     const moduleFile = new ModuleFile("MODULE.bazel");
     expect(moduleFile.version).toEqual("1.2.3");
+  });
+
+  test("returns undefined when the version is missing", () => {
+    mocked(fs.readFileSync).mockReturnValue(`\
+module(name = "rules_foo")
+`);
+    const moduleFile = new ModuleFile("MODULE.bazel");
+    expect(moduleFile.version).toBeUndefined();
   });
 });
 
@@ -59,6 +67,21 @@ describe("stampVersion", () => {
     expect(moduleFile.content).toEqual(
       fakeModuleFile({ moduleName: "rules_foo", version: "4.5.6" })
     );
+  });
+
+  test("stamps the version when the version field was originally missing", () => {
+    mocked(fs.readFileSync).mockReturnValue(`\
+module(
+  name = "rules_foo"
+)`);
+    const moduleFile = new ModuleFile("MODULE.bazel");
+    moduleFile.stampVersion("4.5.6");
+
+    expect(moduleFile.content).toEqual(`\
+module(
+  name = "rules_foo",
+  version = "4.5.6"
+)`);
   });
 });
 

--- a/src/domain/module-file.ts
+++ b/src/domain/module-file.ts
@@ -23,8 +23,8 @@ export class ModuleFile {
 
   public get version(): string {
     const regex = /module\([^)]*?version\s*=\s*"(.+?)"/s;
-    const version = this.moduleContent.match(regex)[1];
-    return version;
+    const match = this.moduleContent.match(regex);
+    return match ? match[1] : "";
   }
 
   public get content(): string {
@@ -32,10 +32,19 @@ export class ModuleFile {
   }
 
   public stampVersion(version: string): void {
-    this.moduleContent = this.moduleContent.replace(
-      /(^.*?module\(.*?version\s*=\s*")[\w.]+(".*$)/s,
-      `$1${version}$2`
-    );
+    if (this.version) {
+      // update the version
+      this.moduleContent = this.moduleContent.replace(
+        /(^.*?module\(.*?version\s*=\s*")[\w.]+(".*$)/s,
+        `$1${version}$2`
+      );
+    } else {
+      // add the version
+      this.moduleContent = this.moduleContent.replace(
+        /(^.*?module\(.*?)\)/s,
+        `$1, version = "${version}")`
+      );
+    }
   }
 
   public save(destPath: string) {

--- a/src/domain/module-file.ts
+++ b/src/domain/module-file.ts
@@ -21,10 +21,10 @@ export class ModuleFile {
     return name;
   }
 
-  public get version(): string {
+  public get version(): string | undefined {
     const regex = /module\([^)]*?version\s*=\s*"(.+?)"/s;
     const match = this.moduleContent.match(regex);
-    return match ? match[1] : "";
+    return match ? match[1] : undefined;
   }
 
   public get content(): string {
@@ -32,7 +32,7 @@ export class ModuleFile {
   }
 
   public stampVersion(version: string): void {
-    if (this.version) {
+    if (this.version !== undefined) {
       // update the version
       this.moduleContent = this.moduleContent.replace(
         /(^.*?module\(.*?version\s*=\s*")[\w.]+(".*$)/s,
@@ -41,8 +41,8 @@ export class ModuleFile {
     } else {
       // add the version
       this.moduleContent = this.moduleContent.replace(
-        /(^.*?module\(.*?)\)/s,
-        `$1, version = "${version}")`
+        /(^.*?module\(.*?)(\s*)\)/s,
+        `$1,\n  version = "${version}"\n)`
       );
     }
   }

--- a/src/domain/module-file.ts
+++ b/src/domain/module-file.ts
@@ -41,8 +41,8 @@ export class ModuleFile {
     } else {
       // add the version
       this.moduleContent = this.moduleContent.replace(
-        /(^.*?module\(.*?)(\s*)\)/s,
-        `$1,\n  version = "${version}"\n)`
+        /(^.*?module\(.*?),?(\s*)\)/s,
+        `$1,\n  version = "${version}",\n)`
       );
     }
   }


### PR DESCRIPTION
Fixes https://github.com/bazel-contrib/publish-to-bcr/issues/95

The `version` attribute is technically [required](https://bazel.build/rules/lib/globals/module#module) for non-root modules, but it should be ok for repos to not have it if they use the publish-to-bcr-bot to automatically patch it in when publishing to BCR.