### PR TITLE
feat: send helpful email when strip prefix is incorrect

### DIFF
--- a/e2e/__snapshots__/e2e.spec.ts.snap
+++ b/e2e/__snapshots__/e2e.spec.ts.snap
@@ -54,6 +54,15 @@ modules/no-prefix/metadata.json
 "
 `;
 
+exports[`e2e tests [snapshot] error message for incorrect strip prefix 1`] = `
+"Failed to publish entry for testorg/versioned@v1.0.0 to the Bazel Central Registry.
+
+Could not find MODULE.bazel in release archive at ./versioned-1.0.0/MODULE.bazel.
+Is the strip prefix in source.template.json correct? (currently it's 'versioned-1.0.0')
+
+"
+`;
+
 exports[`e2e tests [snapshot] missing strip prefix 1`] = `
 "----------------------------------------------------
 modules/empty-prefix/1.0.0/MODULE.bazel

--- a/e2e/fixtures/multi-module/.bcr/source.template.json
+++ b/e2e/fixtures/multi-module/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
-  "strip_prefix": "{REPO}-{VERSION}",
+  "strip_prefix": "{REPO}-{VERSION}/submodule",
   "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/module-{TAG}.tar.gz"
 }

--- a/e2e/helpers/email.ts
+++ b/e2e/helpers/email.ts
@@ -41,17 +41,10 @@ export async function fetchEmails(
     )) {
       messages.push(await mailparser.simpleParser(message.source, {}));
     }
+    await emailClient.messageFlagsAdd({ seq: "1:*", seen: false }, ["\\Seen"]);
   } finally {
     await emailClient.mailboxClose();
   }
 
   return messages;
-}
-
-export async function deleteAllMail(emailClient: ImapFlow): Promise<void> {
-  try {
-    await emailClient.messageDelete("1:*");
-  } finally {
-    await emailClient.mailboxClose();
-  }
 }


### PR DESCRIPTION
This is one of the most common failures for first time releases, but a generic "something went wrong" email was sent

Closes #83 