### PR TITLE
Add missing Bazel version to templates

### DIFF
--- a/templates/.bcr/presubmit.yml
+++ b/templates/.bcr/presubmit.yml
@@ -4,9 +4,11 @@ bcr_test_module:
   module_path: "e2e/bzlmod"
   matrix:
     platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       test_targets:
         - "//..."

--- a/templates/README.md
+++ b/templates/README.md
@@ -51,10 +51,12 @@ bcr_test_module:
   module_path: "e2e/bzlmod"
   matrix:
     platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
   tasks:
     run_tests:
       name: "Run test module"
       platform: ${{ platform }}
+      bazel: ${{ bazel }}
       test_targets:
         - "//..."
 ```


### PR DESCRIPTION
When following the step 2 from [the guide](https://github.com/bazel-contrib/publish-to-bcr/blob/main/README.md) I received a CI error in my PR to the BCR.

The error was mentioning a missing Bazel version in the pre-submit test. Taking inspiration from other modules I added it and the CI became green.
To my understanding specifying a Bazel version for the pre-submit template is by now mandatory and missing in the guide.