### PR TITLE
feat: stop tagging author and maintainers in pr body

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Prepare your ruleset for bzlmod by following the [Bzlmod User Guide](https://baz
    _Note: Authors of rulesets under the `bazelbuild` org should add the app to their personal fork of `bazelbuild/bazel-central-registry`._
 
 1. Include these [template files](./templates) in your ruleset repository.
-1. Cut a release. You will be tagged in a pull request against the BCR.
+1. Cut a release. A pull request like [this](https://github.com/bazelbuild/bazel-central-registry/pull/1601) will be opened against the BCR.
 
 ## Publishing multiple modules in the same repo
 

--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -441,10 +441,6 @@ describe("e2e tests", () => {
       })
     );
 
-    // PR body tags releaser and maintainer
-    expect(body.body).toEqual(expect.stringContaining(`@${releaser.login}`));
-    expect(body.body).toEqual(expect.stringContaining(`@foobar`));
-
     // PR body has a link to the github release
     expect(body.body).toEqual(
       expect.stringContaining(

--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -270,8 +270,6 @@ export class ReleaseEventHandler {
         bcrFork,
         bcr,
         branch,
-        releaser,
-        rulesetRepo.metadataTemplate(moduleRoot).maintainers,
         rulesetRepo.getModuleName(moduleRoot),
         releaseUrl
       );

--- a/src/domain/publish-entry.spec.ts
+++ b/src/domain/publish-entry.spec.ts
@@ -19,19 +19,12 @@ describe("sendRequest", () => {
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
     const tag = "v1.0.0";
-    const releaser = {
-      name: "Json Bearded",
-      username: "json",
-      email: "jason@foo.org",
-    };
 
     await publishEntryService.sendRequest(
       tag,
       bcrFork,
       bcr,
       branch,
-      releaser,
-      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
@@ -51,19 +44,12 @@ describe("sendRequest", () => {
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
     const tag = "v1.0.0";
-    const releaser = {
-      name: "Json Bearded",
-      username: "json",
-      email: "jason@foo.org",
-    };
 
     await publishEntryService.sendRequest(
       tag,
       bcrFork,
       bcr,
       branch,
-      releaser,
-      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
@@ -86,56 +72,17 @@ describe("sendRequest", () => {
     );
   });
 
-  test("tags the releaser in the body", async () => {
-    const bcrFork = new Repository("bazel-central-registry", "bar");
-    const bcr = new Repository("bazel-central-registry", "bazelbuild");
-    const branch = "branch_with_entry";
-    const tag = "v1.0.0";
-    const releaser = {
-      name: "Json Bearded",
-      username: "json",
-      email: "jason@foo.org",
-    };
-
-    await publishEntryService.sendRequest(
-      tag,
-      bcrFork,
-      bcr,
-      branch,
-      releaser,
-      [],
-      "rules_foo",
-      `github.com/aspect-build/rules_foo/releases/tag/${tag}`
-    );
-
-    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
-      expect.any(Repository),
-      expect.any(String),
-      expect.any(Repository),
-      expect.any(String),
-      expect.any(String),
-      expect.stringContaining(`@${releaser.username}`)
-    );
-  });
-
   test("includes the release url in the body", async () => {
     const bcrFork = new Repository("bazel-central-registry", "bar");
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
     const tag = "v1.0.0";
-    const releaser = {
-      name: "Json Bearded",
-      username: "json",
-      email: "jason@foo.org",
-    };
 
     await publishEntryService.sendRequest(
       tag,
       bcrFork,
       bcr,
       branch,
-      releaser,
-      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
@@ -152,83 +99,11 @@ describe("sendRequest", () => {
     );
   });
 
-  test("tags all maintainers with github handles in the body", async () => {
+  test("returns the created pull request number", async () => {
     const bcrFork = new Repository("bazel-central-registry", "bar");
     const bcr = new Repository("bazel-central-registry", "bazelbuild");
     const branch = "branch_with_entry";
     const tag = "v1.0.0";
-    const releaser = {
-      name: "Json Bearded",
-      username: "json",
-      email: "jason@foo.org",
-    };
-    const maintainers = [
-      { name: "M1", github: "m1" },
-      { name: "M2", email: "m2@foo-maintainer.org" },
-      { name: "M3", github: "m3", email: "m3@foo-maintainer.org" },
-      { name: "M4" },
-    ];
-
-    await publishEntryService.sendRequest(
-      tag,
-      bcrFork,
-      bcr,
-      branch,
-      releaser,
-      maintainers,
-      "rules_foo",
-      `github.com/aspect-build/rules_foo/releases/tag/${tag}`
-    );
-
-    const body = mockGithubClient.createPullRequest.mock.calls[0][5];
-    expect(body.includes("@m1")).toEqual(true);
-    expect(body.includes("@m2")).toEqual(false);
-    expect(body.includes("@m3")).toEqual(true);
-    expect(body.includes("@m4")).toEqual(false);
-  });
-
-  test("does not double tag the release author if they are also a maintainer", async () => {
-    const bcrFork = new Repository("bazel-central-registry", "bar");
-    const bcr = new Repository("bazel-central-registry", "bazelbuild");
-    const branch = "branch_with_entry";
-    const tag = "v1.0.0";
-    const releaser = {
-      name: "Json Bearded",
-      username: "json",
-      email: "jason@foo.org",
-    };
-    const maintainers = [
-      { name: "M1", github: "m1" },
-      { name: releaser.name, github: releaser.username },
-    ];
-
-    await publishEntryService.sendRequest(
-      tag,
-      bcrFork,
-      bcr,
-      branch,
-      releaser,
-      maintainers,
-      "rules_foo",
-      `github.com/aspect-build/rules_foo/releases/tag/${tag}`
-    );
-
-    const body = mockGithubClient.createPullRequest.mock.calls[0][5];
-    expect(
-      (body.match(new RegExp(`@${releaser.username}`, "gm")) || []).length
-    ).toEqual(1);
-  });
-
-  test("creates the created pull request number", async () => {
-    const bcrFork = new Repository("bazel-central-registry", "bar");
-    const bcr = new Repository("bazel-central-registry", "bazelbuild");
-    const branch = "branch_with_entry";
-    const tag = "v1.0.0";
-    const releaser = {
-      name: "Json Bearded",
-      username: "json",
-      email: "jason@foo.org",
-    };
 
     mockGithubClient.createPullRequest.mockResolvedValueOnce(4);
 
@@ -237,8 +112,6 @@ describe("sendRequest", () => {
       bcrFork,
       bcr,
       branch,
-      releaser,
-      [],
       "rules_foo",
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );

--- a/src/domain/publish-entry.ts
+++ b/src/domain/publish-entry.ts
@@ -1,8 +1,6 @@
 import { GitHubClient } from "../infrastructure/github.js";
-import { Maintainer } from "./metadata-file.js";
 import { Repository } from "./repository.js";
 import { RulesetRepository } from "./ruleset-repository.js";
-import { User } from "./user.js";
 
 export class PublishEntryService {
   constructor(private readonly githubClient: GitHubClient) {}
@@ -12,18 +10,10 @@ export class PublishEntryService {
     bcrForkRepo: Repository,
     bcr: Repository,
     branch: string,
-    releaser: User,
-    maintainers: ReadonlyArray<Maintainer>,
     moduleName: string,
     releaseUrl: string
   ): Promise<number> {
     const version = RulesetRepository.getVersionFromTag(tag);
-
-    // Only tag maintainers that have a github handle, which is optional:
-    // See: https://docs.google.com/document/d/1moQfNcEIttsk6vYanNKIy3ZuK53hQUFq1b1r0rmsYVg/edit#bookmark=id.1i90c6c14zvx
-    const maintainersToTag = maintainers
-      .filter((m) => !!m.github && m.github !== releaser.username)
-      .map((m) => `@${m.github}`);
 
     const pr = await this.githubClient.createPullRequest(
       bcrForkRepo,
@@ -33,10 +23,6 @@ export class PublishEntryService {
       `${moduleName}@${version}`,
       `\
 Release: ${releaseUrl}
-
-Author: @${releaser.username}
-
-${maintainersToTag.length > 0 ? "fyi: " + maintainersToTag.join(", ") : ""}
 
 _Automated by [Publish to BCR](https://github.com/apps/publish-to-bcr)_`
     );

--- a/templates/README.md
+++ b/templates/README.md
@@ -14,7 +14,7 @@ For more information about the files that make up a BCR entry, see the [Bzlmod U
 Insert your ruleset's homepage and fill out the list of maintainers. Replace `OWNER/REPO` with your repository's
 canonical name. Leave `versions` alone as this will be filled automatically.
 
-_Note_: Maintainers will be emailed if any releases fail and will be tagged on the BCR pull request.
+_Note_: Maintainers will be emailed if a release fails.
 
 ```jsonc
 {


### PR DESCRIPTION
The Bazel Central Registry now has a bot that tags maintainers in a comment prompting them to review the PR. This makes the mentions in the PR body redundant, and additionally causes log spam since the mentions end up in commit messages. Remove all mentions of users from the PR body.