### PR TITLE
feat: make git pushes more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.4.0",
     "axios-retry": "^4.0.0",
     "diff": "^5.1.0",
+    "exponential-backoff": "3.1.1",
     "extract-zip": "^2.0.1",
     "gcp-metadata": "^6.0.0",
     "nodemailer": "^6.7.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,6 +2408,11 @@ expect@^28.0.0, expect@^28.1.3:
     jest-message-util "^28.1.3"
     jest-util "^28.1.3"
 
+exponential-backoff@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.1.tgz#64ac7526fe341ab18a39016cd22c787d01e00bf6"
+  integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
+
 express@^4.14.0, express@^4.16.4:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"


### PR DESCRIPTION
Add retries with exponential backoff to the push to the BCR fork. Occasionally GitHub randomly errors out on the push causing an entry to fail to be created.

Part of https://github.com/bazel-contrib/publish-to-bcr/issues/94