### PR TITLE
fix: don't assume MODULE.bazel file in ruleset repo

### DIFF
--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -246,7 +246,7 @@ export class ReleaseEventHandler {
     console.log(`Attempting publish to fork ${bcrFork.canonicalName}.`);
 
     try {
-      await createEntryService.createEntryFiles(
+      const {moduleName} = await createEntryService.createEntryFiles(
         rulesetRepo,
         bcr,
         tag,
@@ -270,7 +270,7 @@ export class ReleaseEventHandler {
         bcrFork,
         bcr,
         branch,
-        rulesetRepo.getModuleName(moduleRoot),
+        moduleName,
         releaseUrl
       );
 

--- a/src/domain/create-entry.spec.ts
+++ b/src/domain/create-entry.spec.ts
@@ -191,6 +191,18 @@ describe("createEntryFiles", () => {
     );
   });
 
+  test("returns the module name from the release archive", async () => {
+    mockRulesetFiles({extractedModuleName: "foomodule"});
+
+    const tag = "v1.2.3";
+    const rulesetRepo = await RulesetRepository.create("repo", "owner", tag);
+    const bcrRepo = CANONICAL_BCR;
+
+    const result = await createEntryService.createEntryFiles(rulesetRepo, bcrRepo, tag, ".");
+
+    expect(result.moduleName).toEqual("foomodule");
+  });
+
   test("cleans up the release archive extraction", async () => {
     mockRulesetFiles();
 

--- a/src/domain/create-entry.ts
+++ b/src/domain/create-entry.ts
@@ -42,7 +42,7 @@ export class CreateEntryService {
     bcrRepo: Repository,
     tag: string,
     moduleRoot: string
-  ): Promise<void> {
+  ): Promise<{moduleName: string}> {
     await Promise.all([rulesetRepo.checkout(tag), bcrRepo.checkout("main")]);
 
     const version = RulesetRepository.getVersionFromTag(tag);
@@ -105,6 +105,8 @@ export class CreateEntryService {
         rulesetRepo.presubmitPath(moduleRoot),
         path.join(bcrVersionEntryPath, "presubmit.yml")
       );
+
+      return {moduleName: moduleFile.moduleName };
     } finally {
       releaseArchive.cleanup();
     }

--- a/src/domain/ruleset-repository.ts
+++ b/src/domain/ruleset-repository.ts
@@ -4,7 +4,6 @@ import yaml from "yaml";
 import { Configuration } from "./config.js";
 import { UserFacingError } from "./error.js";
 import { MetadataFile, MetadataFileError } from "./metadata-file.js";
-import { ModuleFile } from "./module-file.js";
 import { Repository } from "./repository.js";
 import {
   SourceTemplate,
@@ -250,11 +249,6 @@ export class RulesetRepository extends Repository {
 
   public get config(): Configuration {
     return this._config;
-  }
-
-  public getModuleName(moduleRoot: string): string {
-    return new ModuleFile(path.join(this.diskPath, moduleRoot, "MODULE.bazel"))
-      .moduleName;
   }
 }
 


### PR DESCRIPTION
Read the module name from the release archive rather than the ruleset repo when opening a pull request. A MODULE.bazel file should not be required to be present in the repo.