### PR TITLE
chore: increase memory limit to 1024mb

### DIFF
--- a/deployment/modules/webhook/main.tf
+++ b/deployment/modules/webhook/main.tf
@@ -37,7 +37,7 @@ resource "google_cloudfunctions_function" "publish_to_bcr_function" {
   description = "Handle incoming github events"
   runtime     = "nodejs18"
 
-  available_memory_mb   = 512
+  available_memory_mb   = 1024
   source_archive_bucket = google_storage_bucket.source_archive_bucket.name
   source_archive_object = google_storage_bucket_object.publish_to_bcr_function_bucket_object.name
   trigger_http          = true


### PR DESCRIPTION
The cloud function was running out of memory when processing releases for some repositories, including [protobuf](https://github.com/bazel-contrib/publish-to-bcr/issues/165).