### PR TITLE
Retry on HTTP 404

### DIFF
--- a/src/domain/release-archive.spec.ts
+++ b/src/domain/release-archive.spec.ts
@@ -76,6 +76,11 @@ describe("fetch", () => {
 
     expect(axiosRetry).toHaveBeenCalledWith(axios, {
       retries: 3,
+      retryCondition: expect.matchesPredicate((retryConditionFn: Function) => {
+        // Make sure HTTP 404 errors are retried.
+        let notFoundError = { response: { status: 404 } };
+        return retryConditionFn.call(this, notFoundError);
+      }),
       retryDelay: expect.matchesPredicate((retryDelayFn: Function) => {
         // Make sure the retry delays follow exponential backoff
         // and the final retry happens after at least 1 minute total


### PR DESCRIPTION
Follow-up to #170. I suppose this is what we get for unit-testing but not e2e-testing. On the other hand, I don't have the means to e2e-test this myself, so this is the best I can do right now.