### PR TITLE
fix: recognize explicitly empty version strings

### DIFF
--- a/e2e/__snapshots__/e2e.spec.ts.snap
+++ b/e2e/__snapshots__/e2e.spec.ts.snap
@@ -316,7 +316,7 @@ modules/unversioned/1.0.0/MODULE.bazel
 ----------------------------------------------------
 module(
     name = \\"unversioned\\",
-  version = \\"1.0.0\\",
+    version = \\"1.0.0\\",
 )
 
 ----------------------------------------------------
@@ -329,7 +329,7 @@ modules/unversioned/1.0.0/patches/module_dot_bazel_version.patch
  module(
 -    name = \\"unversioned\\"
 +    name = \\"unversioned\\",
-+  version = \\"1.0.0\\",
++    version = \\"1.0.0\\",
  )
 
 ----------------------------------------------------
@@ -356,7 +356,7 @@ modules/unversioned/1.0.0/source.json
     \\"strip_prefix\\": \\"unversioned-1.0.0\\",
     \\"url\\": \\"https://github.com/testorg/unversioned/archive/refs/tags/v1.0.0.tar.gz\\",
     \\"patches\\": {
-        \\"module_dot_bazel_version.patch\\": \\"sha256-LGXyh9FLhgIPbe0gHfxAPnEQ7HVR+HUP/IDbPdl3ZkA=\\"
+        \\"module_dot_bazel_version.patch\\": \\"sha256-kZesuygBz9d247Nv0mshe3bXxzIo+Ly4X0wYy8HYVEQ=\\"
     },
     \\"patch_strip\\": 1
 }
@@ -545,7 +545,7 @@ bcr_test_module:
 modules/zip/1.0.0/source.json
 ----------------------------------------------------
 {
-    \\"integrity\\": \\"sha256-fencLRegfGaNYdAWP/WaXxUWJwzD19XQtpWf2qcmkZw=\\",
+    \\"integrity\\": \\"sha256-Bqu+8wSwNVkplPEHcMNdla+oQRGoyXfx4BohYHCPZFU=\\",
     \\"strip_prefix\\": \\"zip-1.0.0\\",
     \\"url\\": \\"https://github.com/testorg/zip/archive/refs/tags/v1.0.0.zip\\"
 }

--- a/src/domain/module-file.spec.ts
+++ b/src/domain/module-file.spec.ts
@@ -110,7 +110,7 @@ module(
     repo_name = "bazel_gazelle",
 )
 
-bazel_dep(name = "bazel_features", version = "1.2.3")`);
+bazel_dep(name = "bazel_features", version = "1.9.1")`);
     const moduleFile = new ModuleFile("MODULE.bazel");
     moduleFile.stampVersion("4.5.6");
 

--- a/src/domain/module-file.spec.ts
+++ b/src/domain/module-file.spec.ts
@@ -72,33 +72,83 @@ describe("stampVersion", () => {
   test("stamps the version when the version field was originally missing", () => {
     mocked(fs.readFileSync).mockReturnValue(`\
 module(
-  name = "rules_foo"
+    name = "rules_foo"
 )`);
     const moduleFile = new ModuleFile("MODULE.bazel");
     moduleFile.stampVersion("4.5.6");
 
     expect(moduleFile.content).toEqual(`\
 module(
-  name = "rules_foo",
-  version = "4.5.6",
+    name = "rules_foo",
+    version = "4.5.6",
 )`);
   });
 
   test("stamps the version when the version field was originally missing and the last field is comma-trailed", () => {
     mocked(fs.readFileSync).mockReturnValue(`\
 module(
-  name = "rules_foo",
-  compatibility_level = 1,
+    name = "rules_foo",
+    compatibility_level = 1,
 )`);
     const moduleFile = new ModuleFile("MODULE.bazel");
     moduleFile.stampVersion("4.5.6");
 
     expect(moduleFile.content).toEqual(`\
 module(
-  name = "rules_foo",
-  compatibility_level = 1,
-  version = "4.5.6",
+    name = "rules_foo",
+    compatibility_level = 1,
+    version = "4.5.6",
 )`);
+  });
+
+  test("stamps the version when the version field was set to the empty string", () => {
+    mocked(fs.readFileSync).mockReturnValue(`\
+module(
+    name = "gazelle",
+    # Updated by the Publish to BCR app.
+    version = "",
+    repo_name = "bazel_gazelle",
+)
+
+bazel_dep(name = "bazel_features", version = "1.2.3")`);
+    const moduleFile = new ModuleFile("MODULE.bazel");
+    moduleFile.stampVersion("4.5.6");
+
+    expect(moduleFile.content).toEqual(`\
+module(
+    name = "gazelle",
+    # Updated by the Publish to BCR app.
+    version = "4.5.6",
+    repo_name = "bazel_gazelle",
+)
+
+bazel_dep(name = "bazel_features", version = "1.9.1")`);
+  });
+
+
+  test("stamps the version when the version field was missing but the module call ends with a comment", () => {
+    mocked(fs.readFileSync).mockReturnValue(`\
+module(
+    name = "gazelle",
+    repo_name = "bazel_gazelle",
+    # version is set by the Publish to BCR app.
+)
+
+bazel_dep(name = "bazel_features", version = "1.9.1")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")`);
+    const moduleFile = new ModuleFile("MODULE.bazel");
+    moduleFile.stampVersion("4.5.6");
+
+    expect(moduleFile.content).toEqual(`\
+module(
+    name = "gazelle",
+    repo_name = "bazel_gazelle",
+    # version is set by the Publish to BCR app.,
+    version = "4.5.6",
+)
+
+bazel_dep(name = "bazel_features", version = "1.9.1")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")`);
   });
 });
 

--- a/src/domain/module-file.ts
+++ b/src/domain/module-file.ts
@@ -35,14 +35,14 @@ export class ModuleFile {
     if (this.version !== undefined) {
       // update the version
       this.moduleContent = this.moduleContent.replace(
-        /(^.*?module\(.*?version\s*=\s*")[\w.]+(".*$)/s,
+        /(^.*?module\(.*?version\s*=\s*")[\w.]*(".*$)/s,
         `$1${version}$2`
       );
     } else {
       // add the version
       this.moduleContent = this.moduleContent.replace(
         /(^.*?module\(.*?),?(\s*)\)/s,
-        `$1,\n  version = "${version}",\n)`
+        `$1,\n    version = "${version}",\n)`
       );
     }
   }


### PR DESCRIPTION
A `module` directive with `version = ""` resulted in the version being stamped into the first `bazel_dep`.

Also fix the indentation to follow `buildifier`'s style.