### PR TITLE
fix: xz decompression issues

### DIFF
--- a/src/domain/release-archive.ts
+++ b/src/domain/release-archive.ts
@@ -99,6 +99,11 @@ export class ReleaseArchive {
         cwd: extractDir
       });
       await decompressXz(reader, writer);
+      await new Promise(resolve => {
+        writer.on('finish', resolve);
+        writer.end();
+      });
+      
       return;
     }
 

--- a/src/infrastructure/xzdec/xzdec.ts
+++ b/src/infrastructure/xzdec/xzdec.ts
@@ -126,7 +126,14 @@ export async function decompress(r: stream.Readable, w: stream.Writable) {
           }
           const outputLen = peekU32(mem, outputLenPtr);
           if (outputLen > 0) {
-            w.write(Buffer.from(mem.buffer, outputPtr, outputLen));
+            await new Promise((resolve) => {
+              if (!w.write(Buffer.from(mem.buffer, outputPtr, outputLen))) {
+                w.once('drain', resolve)
+              }
+              else {
+                resolve(null);
+              }
+            });
           }
         }
       }


### PR DESCRIPTION
Wait for the writable stream to end before reading the extracted module file. Also pause subsequent writes while the write buffer needs to be drained. It's not clear why the latter is necessary as the [docs](https://nodejs.org/api/stream.html#writablewritechunk-encoding-callback) suggest you can continue to do writes while undrained content continues to be buffered in memory. However, this seems to fix an issue where the extracted content was incorrect.

Example of a working publish on the dev environment: https://github.com/publish-to-bcr-dev-registry/bazel-central-registry/pull/82.

Closes https://github.com/bazel-contrib/publish-to-bcr/issues/176.