### PR TITLE
fix: fix prebuild script not executing after pnpm migration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,6 @@
 # projects using rules_js so that pnpm outside of Bazel lays out a node_modules tree similar to what
 # rules_js lays out under Bazel (without a hidden node_modules/.pnpm/node_modules)
 hoist=false
+
+# Pre and post scripts don't run by default like they do with npm and yarn
+enable-pre-post-scripts=true


### PR DESCRIPTION
Pnpm disables these scripts by default.