### PR TITLE
fix: don't run build script on cloud function deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "prebuild": "node tools/clean-dist-files.js",
     "build": "tsc && node tools/copy-dist-files.js",
+    "//gcp-build": "Don't run any build steps on cloud run. See https://cloud.google.com/functions/docs/concepts/nodejs-runtime#npm_build_script/",
+    "gcp-build": "",
     "test": "jest src",
     "pree2e": "pnpm run build",
     "e2e": "jest e2e"


### PR DESCRIPTION
This must be new because I haven't run into this before, but deploying a cloud function runs the `build` script in package.json. This will fail on cloud run because the build script relies on local scripts that we don't publish. We have no need for building on cloud run since we upload an already built artifact.