### PR TITLE
refactor: fix a layer violation causing a circular dependency

### DIFF
--- a/e2e/e2e.spec.ts
+++ b/e2e/e2e.spec.ts
@@ -729,7 +729,7 @@ describe("e2e tests", () => {
     });
 
     fakeGitHub.mockUser({
-      login: GitHubClient.GITHUB_ACTIONS_BOT.username,
+      login: GitHubClient.GITHUB_ACTIONS_BOT.login,
       id: GitHubClient.GITHUB_ACTIONS_BOT.id,
     });
     fakeGitHub.mockUser({ login: "publish-to-bcr-bot[bot]", id: 123 });

--- a/src/application/notifications.ts
+++ b/src/application/notifications.ts
@@ -1,10 +1,9 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
 import { UserFacingError } from "../domain/error.js";
 import { Maintainer } from "../domain/metadata-file.js";
 import { Repository } from "../domain/repository.js";
-import { User } from "../domain/user.js";
+import { User, UserService } from "../domain/user.js";
 import { Authentication, EmailClient } from "../infrastructure/email.js";
-import { GitHubClient } from "../infrastructure/github.js";
 import { SecretsClient } from "../infrastructure/secrets.js";
 
 @Injectable()
@@ -16,7 +15,7 @@ export class NotificationsService {
   constructor(
     private readonly emailClient: EmailClient,
     private readonly secretsClient: SecretsClient,
-    @Inject("rulesetRepoGitHubClient") private githubClient: GitHubClient
+    private readonly userService: UserService
   ) {
     if (process.env.NOTIFICATIONS_EMAIL === undefined) {
       throw new Error("Missing NOTIFICATIONS_EMAIL environment variable.");
@@ -70,7 +69,7 @@ export class NotificationsService {
     const fetchedEmails = (
       await Promise.all(
         maintainersWithOnlyGithubHandle.map((m) =>
-          this.githubClient.getRepoUser(m.github, rulesetRepo)
+          this.userService.getUser(m.github)
         )
       )
     )

--- a/src/application/webhook/app.module.ts
+++ b/src/application/webhook/app.module.ts
@@ -2,6 +2,8 @@ import { Module } from "@nestjs/common";
 import { CreateEntryService } from "../../domain/create-entry.js";
 import { FindRegistryForkService } from "../../domain/find-registry-fork.js";
 import { PublishEntryService } from "../../domain/publish-entry.js";
+import { RepositoryService } from "../../domain/repository.js";
+import { UserService } from "../../domain/user.js";
 import { EmailClient } from "../../infrastructure/email.js";
 import { GitClient } from "../../infrastructure/git.js";
 import { SecretsClient } from "../../infrastructure/secrets.js";
@@ -24,6 +26,8 @@ import {
     CreateEntryService,
     FindRegistryForkService,
     PublishEntryService,
+    RepositoryService,
+    UserService,
     APP_OCTOKIT_PROVIDER,
     BCR_APP_OCTOKIT_PROVIDER,
     RULESET_REPO_GITHUB_CLIENT_PROVIDER,

--- a/src/application/webhook/providers.ts
+++ b/src/application/webhook/providers.ts
@@ -47,7 +47,8 @@ export const RULESET_REPO_GITHUB_CLIENT_PROVIDER: Provider = {
 
     const githubClient = await GitHubClient.forRepoInstallation(
       appOctokit,
-      rulesetRepo,
+      rulesetRepo.owner,
+      rulesetRepo.name,
       installationId
     );
     return githubClient;
@@ -67,7 +68,8 @@ export const BCR_GITHUB_CLIENT_PROVIDER: Provider = {
 
     const githubClient = await GitHubClient.forRepoInstallation(
       bcrAppOctokit,
-      bcr
+      bcr.owner,
+      bcr.name
     );
     return githubClient;
   },

--- a/src/domain/publish-entry.spec.ts
+++ b/src/domain/publish-entry.spec.ts
@@ -30,9 +30,10 @@ describe("publish", () => {
     );
 
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
-      bcrFork,
+      bcrFork.owner,
       branch,
-      bcr,
+      bcr.owner,
+      bcr.name,
       "main",
       expect.any(String),
       expect.any(String)
@@ -55,17 +56,19 @@ describe("publish", () => {
     );
 
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
-      expect.any(Repository),
       expect.any(String),
-      expect.any(Repository),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
       expect.any(String),
       expect.stringContaining("rules_foo"),
       expect.any(String)
     );
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
-      expect.any(Repository),
       expect.any(String),
-      expect.any(Repository),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
       expect.any(String),
       expect.stringContaining("1.0.0"),
       expect.any(String)
@@ -88,25 +91,28 @@ describe("publish", () => {
     );
 
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
-      expect.any(Repository),
       expect.any(String),
-      expect.any(Repository),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
       expect.any(String),
       expect.stringContaining("rules_foo"),
       expect.any(String)
     );
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
-      expect.any(Repository),
       expect.any(String),
-      expect.any(Repository),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
       expect.any(String),
       expect.stringContaining("rules_bar"),
       expect.any(String)
     );
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
-      expect.any(Repository),
       expect.any(String),
-      expect.any(Repository),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
       expect.any(String),
       expect.stringContaining("1.0.0"),
       expect.any(String)
@@ -129,9 +135,10 @@ describe("publish", () => {
     );
 
     expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
-      expect.any(Repository),
       expect.any(String),
-      expect.any(Repository),
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
       expect.any(String),
       expect.any(String),
       expect.stringContaining(

--- a/src/domain/publish-entry.ts
+++ b/src/domain/publish-entry.ts
@@ -18,9 +18,10 @@ export class PublishEntryService {
     const version = RulesetRepository.getVersionFromTag(tag);
 
     const pullNumber = await this.githubClient.createPullRequest(
-      bcrForkRepo,
+      bcrForkRepo.owner,
       branch,
-      bcr,
+      bcr.owner,
+      bcr.name,
       "main",
       moduleNames.map((moduleName) => `${moduleName}@${version}`).join(", "),
       `\
@@ -30,9 +31,11 @@ _Automated by [Publish to BCR](https://github.com/apps/publish-to-bcr)_`
     );
 
     try {
-      await this.githubClient.enableAutoMerge(bcr, pullNumber);
+      await this.githubClient.enableAutoMerge(bcr.owner, bcr.name, pullNumber);
     } catch (e) {
-      console.error(`Error: Failed to enable auto-merge on pull request github.com/${bcr.canonicalName}/pull/${pullNumber}.`)
+      console.error(
+        `Error: Failed to enable auto-merge on pull request github.com/${bcr.canonicalName}/pull/${pullNumber}.`
+      );
     }
 
     return pullNumber;

--- a/src/domain/user.ts
+++ b/src/domain/user.ts
@@ -1,6 +1,34 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { GitHubClient, User as GitHubUser } from "../infrastructure/github.js";
+
 export interface User {
   readonly id?: number;
   readonly name?: string;
   readonly username: string;
   readonly email: string;
+}
+
+@Injectable()
+export class UserService {
+  constructor(
+    @Inject("rulesetRepoGitHubClient") private githubClient: GitHubClient
+  ) {}
+
+  public static isGitHubActionsBot(user: User): boolean {
+    return user.username === GitHubClient.GITHUB_ACTIONS_BOT.login;
+  }
+
+  public static fromGitHubUser(user: GitHubUser): User {
+    return {
+      id: user.id,
+      name: user.name,
+      username: user.login,
+      email: user.email,
+    };
+  }
+
+  public async getUser(username: string): Promise<User> {
+    const user = await this.githubClient.getUserByUsername(username);
+    return UserService.fromGitHubUser(user);
+  }
 }


### PR DESCRIPTION
Remove references from the `domain` layer out of the `infrastructure` layer. This caused circular dependencies when converting this repo to build with bazel.