### PR TITLE
refactor: remove fake google credentials

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,14 +42,5 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-      # Setup gcloud application default credentials. While the credentials are not actually
-      # used because Google api services are stubbed, instantiating any of the Google node
-      # clients requires the credentials file to exist and be valid.
-      - uses: "google-github-actions/auth@v2"
-        with:
-          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
-      - uses: google-github-actions/setup-gcloud@v2
-        with:
-          version: ">= 363.0.0"
       - run: pnpm install --frozen-lockfile
       - run: pnpm run e2e

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "exponential-backoff": "3.1.1",
     "extract-zip": "^2.0.1",
     "gcp-metadata": "^6.0.0",
+    "google-auth-library": "^9.15.0",
     "nodemailer": "^6.7.8",
     "reflect-metadata": "^0.2.2",
     "rxjs": "7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ dependencies:
   gcp-metadata:
     specifier: ^6.0.0
     version: 6.1.0
+  google-auth-library:
+    specifier: ^9.15.0
+    version: 9.15.0
   nodemailer:
     specifier: ^6.7.8
     version: 6.9.16

--- a/src/infrastructure/secrets.ts
+++ b/src/infrastructure/secrets.ts
@@ -1,6 +1,7 @@
 import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
 import { Injectable } from "@nestjs/common";
 import gcpMetadata from "gcp-metadata";
+import type { JSONClient } from "google-auth-library/build/src/auth/googleauth";
 
 @Injectable()
 export class SecretsClient {
@@ -15,6 +16,14 @@ export class SecretsClient {
         fallback: "rest",
         protocol: "http",
         port: Number(process.env.SECRET_MANAGER_PORT),
+        // Create a fake auth client to bypass checking for default credentials
+        authClient: {
+          getRequestHeaders(
+            url?: string
+          ): Promise<{ [index: string]: string }> {
+            return Promise.resolve({});
+          },
+        } as JSONClient,
       });
     } else {
       this.googleSecretsClient = new SecretManagerServiceClient();


### PR DESCRIPTION
In integration tests the google node client  would fail unless it could load some default credentials, even though the secrets endpoint is stubbed and the credentials are not actually used. My previous solution was to add some credentials as a secret which prevented e2e tests from running on fork builds.

I found a simpler way to mock the auth client removing the need for any secrets.

This is also a prefactor for running the e2e tests under bazel, which can't find default credentials on the home directory when run in the sandbox.