### PR TITLE
chore: disable e2e tests while ethereal mail is down

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -7,6 +7,11 @@ tasks:
   - configure:
       queue: aspect-medium
   - test:
+      targets:
+        - //...
+        # Disable e2e tests while ethereal mail is down
+        # https://github.com/nodemailer/nodemailer/issues/1710
+        - -//e2e:test
   - finalization:
       queue: aspect-small
 notifications:


### PR DESCRIPTION
An external email service we use for testing has been down for over a day. Disable e2es to unblock CI. I will do manual integration testing if I need to deploy anything. If this isn't resolved soon, I'll look into replacing the service.