### PR TITLE
feat(cli): load configuration

### DIFF
--- a/src/application/cli/BUILD.bazel
+++ b/src/application/cli/BUILD.bazel
@@ -16,6 +16,7 @@ ts_project(
         "//:node_modules/@types/node",  # keep
         "//:node_modules/@types/yargs",
         "//:node_modules/yargs",
+        "//src/domain",
     ],
 )
 

--- a/src/application/cli/create-entry-command.ts
+++ b/src/application/cli/create-entry-command.ts
@@ -1,11 +1,39 @@
 import { Injectable } from '@nestjs/common';
+import path from 'path';
 import { ArgumentsCamelCase } from 'yargs';
 
+import {
+  Configuration,
+  MissingConfigurationFileError,
+} from '../../domain/configuration.js';
 import { CreateEntryArgs } from './yargs.js';
 
 @Injectable()
 export class CreateEntryCommand {
   public async handle(_args: ArgumentsCamelCase<CreateEntryArgs>) {
+    this.loadConfiguration(_args.templatesDir);
+
     return Promise.resolve(null);
+  }
+
+  private loadConfiguration(templatesDir: string): Configuration {
+    const filepaths = [
+      path.join(templatesDir, 'config.yml'),
+      path.join(templatesDir, 'config.yaml'),
+    ];
+    for (const filepath of filepaths) {
+      try {
+        return Configuration.fromFile(filepath);
+      } catch (e) {
+        if (e instanceof MissingConfigurationFileError) {
+          continue;
+        }
+        throw e;
+      }
+    }
+
+    // No configuration files at the expected paths. Load the defaults.
+    console.error('No configuration file found; using defaults');
+    return Configuration.defaults();
   }
 }

--- a/src/application/cli/yargs.spec.ts
+++ b/src/application/cli/yargs.spec.ts
@@ -30,23 +30,21 @@ describe('createParser', () => {
   });
 
   describe('create-entry', () => {
-    test('missing --ruleset-repo', async () => {
+    test('missing --templates-dir', async () => {
       expect(() => parser.parse('create-entry')).toThrow(
-        'Missing required argument: ruleset-repo'
+        'Missing required argument: templates-dir'
       );
     });
 
-    test('missing --ruleset-repo arg', () => {
-      expect(() => parser.parse('create-entry --ruleset-repo')).toThrow(
-        'Not enough arguments following: ruleset-repo'
+    test('missing --templates-dir arg', () => {
+      expect(() => parser.parse('create-entry --templates-dir')).toThrow(
+        'Not enough arguments following: templates-dir'
       );
     });
 
-    test('parses --ruleset-repo', async () => {
-      const args = await parser.parse(
-        'create-entry --ruleset-repo git@github.com:org/repo.git'
-      );
-      expect(args.rulesetRepo).toEqual('git@github.com:org/repo.git');
+    test('parses --templates-dir', async () => {
+      const args = await parser.parse('create-entry --templates-dir .bcr');
+      expect(args.templatesDir).toEqual('.bcr');
     });
   });
 });

--- a/src/application/cli/yargs.ts
+++ b/src/application/cli/yargs.ts
@@ -4,7 +4,7 @@ import { hideBin } from 'yargs/helpers';
 import { CreateEntryCommand } from './create-entry-command';
 
 export interface CreateEntryArgs {
-  rulesetRepo: string;
+  templatesDir: string;
 }
 
 export type ApplicationArgs = CreateEntryArgs;
@@ -22,9 +22,9 @@ export function createParser(
       'create-entry',
       'Create a new module version entry for the BCR',
       (yargs) => {
-        yargs.option('ruleset-repo', {
+        yargs.option('templates-dir', {
           describe:
-            'Ruleset repository containing .bcr folder with templates. Can be a remote git url, e.g. `git@github.com:org/repo.git` or local path e.g. `./path/to/repo`.',
+            'Directory containing a config file, BCR templates, and other release files: config.yml, source.template.json, metadata.template.json, presubmit.yaml. Equivalent to the .bcr directory required by the legacy GitHub app.',
           type: 'string',
           required: true,
           requiresArg: true,

--- a/src/domain/BUILD.bazel
+++ b/src/domain/BUILD.bazel
@@ -4,7 +4,7 @@ load("//bazel/ts:defs.bzl", "ts_project")
 ts_project(
     name = "domain",
     srcs = [
-        "config.ts",
+        "configuration.ts",
         "create-entry.ts",
         "error.ts",
         "find-registry-fork.ts",
@@ -41,6 +41,7 @@ ts_project(
     name = "domain_tests",
     testonly = True,
     srcs = [
+        "configuration.spec.ts",
         "create-entry.spec.ts",
         "find-registry-fork.spec.ts",
         "integrity-hash.spec.ts",

--- a/src/domain/config.ts
+++ b/src/domain/config.ts
@@ -1,9 +1,0 @@
-export interface Configuration {
-  readonly fixedReleaser?: FixedReleaser;
-  readonly moduleRoots: string[];
-}
-
-export interface FixedReleaser {
-  readonly login: string;
-  readonly email: string;
-}

--- a/src/domain/configuration.spec.ts
+++ b/src/domain/configuration.spec.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+
+import { mocked } from 'jest-mock';
+
+import { Configuration, InvalidConfigurationFileError } from './configuration';
+
+jest.mock('node:fs');
+
+describe('Configuration', () => {
+  describe('defaults', () => {
+    test('sets module roots to single root', () => {
+      const config = Configuration.defaults();
+
+      expect(config.moduleRoots).toEqual(['.']);
+    });
+
+    test('does not set a fixed releaser', () => {
+      const config = Configuration.defaults();
+
+      expect(config.fixedReleaser).toBeUndefined();
+    });
+  });
+
+  describe('fromFile', () => {
+    test('empty file loads defaults', () => {
+      mockConfig('config.yml', '');
+      const config = Configuration.fromFile('config.yml');
+      expect(config).toEqual(Configuration.defaults());
+    });
+
+    test('loads a fixedReleaser', () => {
+      mockConfig(
+        'config.yml',
+        `\
+fixedReleaser:
+  login: jbedard
+  email: json@bearded.ca                
+`
+      );
+      const config = Configuration.fromFile('config.yml');
+      expect(config.fixedReleaser).toEqual({
+        login: 'jbedard',
+        email: 'json@bearded.ca',
+      });
+    });
+
+    test('throws on invalid fixedReleaser', () => {
+      mockConfig(
+        'config.yml',
+        `\
+fixedReleaser: foobar             
+`
+      );
+
+      expect(() => Configuration.fromFile('config.yml')).toThrowWithMessage(
+        InvalidConfigurationFileError,
+        "Invalid configuration file at config.yml: could not parse 'fixedReleaser'"
+      );
+    });
+
+    test('loads moduleRoots', () => {
+      mockConfig(
+        'config.yml',
+        `\
+moduleRoots: [".", "subdir"]             
+`
+      );
+      const config = Configuration.fromFile('config.yml');
+      expect(config.moduleRoots).toEqual(['.', 'subdir']);
+    });
+
+    test('throws on invalid moduleRoots', () => {
+      mockConfig(
+        'config.yml',
+        `\
+moduleRoots: 123             
+`
+      );
+
+      expect(() => Configuration.fromFile('config.yml')).toThrowWithMessage(
+        InvalidConfigurationFileError,
+        "Invalid configuration file at config.yml: could not parse 'moduleRoots'"
+      );
+    });
+  });
+});
+
+function mockConfig(filepath: string, content: string) {
+  mocked(fs.existsSync).mockImplementation((path: fs.PathLike) => {
+    if (path === filepath) {
+      return true;
+    }
+    return false;
+  });
+
+  mocked(fs.readFileSync).mockImplementation(
+    (path: fs.PathLike, _options: any): any => {
+      if (path === filepath) {
+        return content;
+      }
+      throw new Error(`Unmocked file contents for ${path}`);
+    }
+  );
+}

--- a/src/domain/configuration.ts
+++ b/src/domain/configuration.ts
@@ -1,0 +1,80 @@
+import fs from 'node:fs';
+
+import yaml from 'yaml';
+
+export class MissingConfigurationFileError extends Error {
+  constructor(public readonly filepath: string) {
+    super(`Could not find configuration file at ${filepath}`);
+  }
+}
+
+export class InvalidConfigurationFileError extends Error {
+  constructor(
+    public readonly filepath: string,
+    public readonly reason: string
+  ) {
+    super(`Invalid configuration file at ${filepath}: ${reason}`);
+  }
+}
+
+export class Configuration {
+  public static readonly DEFAULT_MODULE_ROOTS = ['.'];
+
+  public static fromFile(filepath: string): Configuration {
+    if (!fs.existsSync(filepath)) {
+      throw new MissingConfigurationFileError(filepath);
+    }
+
+    let config: Record<string, any>;
+    try {
+      config = yaml.parse(fs.readFileSync(filepath, 'utf-8')) || {};
+    } catch {
+      throw new InvalidConfigurationFileError(
+        filepath,
+        'cannot parse file as yaml'
+      );
+    }
+
+    if (
+      config.fixedReleaser &&
+      (typeof config.fixedReleaser !== 'object' ||
+        typeof config.fixedReleaser.login !== 'string' ||
+        typeof config.fixedReleaser.email !== 'string')
+    ) {
+      throw new InvalidConfigurationFileError(
+        filepath,
+        "could not parse 'fixedReleaser'"
+      );
+    }
+
+    if (
+      config.moduleRoots !== undefined &&
+      (!Array.isArray(config.moduleRoots) ||
+        !config.moduleRoots.every((value) => typeof value === 'string'))
+    ) {
+      throw new InvalidConfigurationFileError(
+        filepath,
+        "could not parse 'moduleRoots'"
+      );
+    }
+
+    config.moduleRoots =
+      config.moduleRoots || Configuration.DEFAULT_MODULE_ROOTS;
+
+    return new Configuration(config.moduleRoots, config.fixedReleaser);
+  }
+
+  public static defaults(): Configuration {
+    return new Configuration(Configuration.DEFAULT_MODULE_ROOTS);
+  }
+
+  private constructor(
+    public readonly moduleRoots: string[],
+    public readonly fixedReleaser?: FixedReleaser
+  ) {}
+}
+
+export interface FixedReleaser {
+  readonly login: string;
+  readonly email: string;
+}

--- a/src/domain/ruleset-repository.spec.ts
+++ b/src/domain/ruleset-repository.spec.ts
@@ -11,9 +11,9 @@ import {
   fakeSourceFile,
 } from '../test/mock-template-files';
 import { expectThrownError } from '../test/util';
-import { FixedReleaser } from './config';
+import { Configuration, FixedReleaser } from './configuration';
 import {
-  InvalidConfigFileError,
+  InvalidConfigurationFileError,
   InvalidMetadataTemplateError,
   InvalidPresubmitFileError,
   InvalidSourceTemplateError,
@@ -146,55 +146,14 @@ describe('create', () => {
     test("defaults configuration when the file doesn't exist", async () => {
       mockRulesetFiles({ configExists: false });
       const rulesetRepo = await RulesetRepository.create('foo', 'bar', 'main');
-      expect(rulesetRepo.config.fixedReleaser).toBeUndefined();
+      expect(rulesetRepo.config).toEqual(Configuration.defaults());
     });
 
-    test('loads a fixedReleaser', async () => {
-      mockRulesetFiles({
-        configExists: true,
-        fixedReleaser: { login: 'jbedard', email: 'json@bearded.ca' },
-      });
-      const rulesetRepo = await RulesetRepository.create('foo', 'bar', 'main');
-      expect(rulesetRepo.config.fixedReleaser).toEqual({
-        login: 'jbedard',
-        email: 'json@bearded.ca',
-      });
-    });
-
-    test('throws on invalid fixedReleaser', async () => {
+    test('throws when the configuration file is invalid', async () => {
       mockRulesetFiles({ configExists: true, invalidFixedReleaser: true });
-      await expectThrownError(
-        () => RulesetRepository.create('foo', 'bar', 'main'),
-        InvalidConfigFileError
-      );
-    });
-
-    test('loads moduleRoots', async () => {
-      mockRulesetFiles({
-        configExists: true,
-        configContent: 'moduleRoots: [".", "subdir"]',
-      });
-    });
-
-    test('defaults moduleRoots to the root dir', async () => {
-      mockRulesetFiles({
-        configExists: true,
-        configContent: '',
-      });
-    });
-
-    test('throws on invalid moduleRoots value', async () => {
-      mockRulesetFiles({
-        configExists: true,
-        configContent: 'moduleRoots: false',
-      });
-    });
-
-    test("throws module root that doesn't exist in repo", async () => {
-      mockRulesetFiles({
-        configExists: true,
-        configContent: 'moduleRoots: ["does/not/exist"]',
-      });
+      await expect(
+        RulesetRepository.create('foo', 'bar', 'main')
+      ).rejects.toThrow(InvalidConfigurationFileError);
     });
 
     test("loads config file with alternate extension 'yaml'", async () => {
@@ -227,15 +186,6 @@ describe('create', () => {
         login: 'jbedard',
         email: 'json@bearded.ca',
       });
-    });
-
-    test('does not complain when the config file is empty', async () => {
-      mockRulesetFiles({
-        configExists: true,
-        configContent: '',
-      });
-
-      await RulesetRepository.create('foo', 'bar', 'main');
     });
   });
 });

--- a/src/test/mock-template-files.ts
+++ b/src/test/mock-template-files.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 
-import { FixedReleaser } from '../domain/config';
+import { FixedReleaser } from '../domain/configuration';
 
 export function fakeModuleFile(
   overrides: {


### PR DESCRIPTION
Load the configuration file in the create entry CLI command. This involves some refactoring of the configuration loading logic out of the RulesetRepository class.

The CLI now takes a `--templates-dir` option rather than a `--ruleset-repo` option. Unlike the app, which needs to know the ruleset repository to clone and checkout to view the files under `.bcr`, the CLI will either be executed inside of an action, where the repo is presumably checked out, or locally, where a release would also have a local checkout. There's no need for the CLI to perform the clone.

Ideally the CLI wouldn't depend on a `.bcr` directory structure, which was added for the app specifically to be able to find template files, but for now that's the easiest migration path. In the future I could add additional args pointing to specific files, e.g., `--config`, `--metadata-template`, etc. For now, it will expect all of the files to exist under the `--templates-dir`.