### PR TITLE
refactor: move push logic out of create entry service

### DIFF
--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -78,7 +78,7 @@ export class ReleaseEventHandler {
           moduleNames.push(moduleName);
         }
 
-        branch = await this.createEntryService.commitEntryToNewBranch(
+        branch = await this.publishEntryService.commitEntryToNewBranch(
           rulesetRepo,
           bcr,
           tag,
@@ -213,7 +213,7 @@ export class ReleaseEventHandler {
     console.log(`Attempting publish to fork ${bcrFork.canonicalName}.`);
 
     try {
-      await this.createEntryService.pushEntryToFork(
+      await this.publishEntryService.pushEntryToFork(
         bcrFork,
         bcr,
         branch,

--- a/src/domain/publish-entry.spec.ts
+++ b/src/domain/publish-entry.spec.ts
@@ -1,17 +1,70 @@
-import { Mocked, mocked } from 'jest-mock';
+import { randomUUID } from 'node:crypto';
 
-import { GitHubClient } from '../infrastructure/github';
+import { backOff, BackoffOptions } from 'exponential-backoff';
+import { Mocked, mocked } from 'jest-mock';
+import path from 'path';
+
+import { GitClient } from '../infrastructure/git';
+import {
+  GitHubApp,
+  GitHubClient,
+  User as GitHubUser,
+} from '../infrastructure/github';
 import { PublishEntryService } from './publish-entry';
 import { Repository } from './repository';
+import { RulesetRepository } from './ruleset-repository';
+import { User, UserService } from './user';
 
+// Fake the BCR Repository with a diskPath so that it
+// doesn't complain about not being checked out.
+const CANONICAL_BCR = {
+  owner: 'bazelbuild',
+  name: 'bazel-central-registry',
+  diskPath: path.join(process.env.TEST_TMPDIR, 'bazel-central-registry'),
+} as Repository;
+
+jest.mock('exponential-backoff');
+jest.mock('../infrastructure/git');
 jest.mock('../infrastructure/github');
+jest.mock('./ruleset-repository', () => {
+  return {
+    RulesetRepository: {
+      getVersionFromTag: jest.requireActual('./ruleset-repository')
+        .RulesetRepository.getVersionFromTag,
+      create(
+        name: string,
+        owner: string,
+        _verifyAtRef?: string
+      ): Promise<RulesetRepository> {
+        // Skip all of the bcr template file validation that would
+        // normally occur in a RulesetRepository since it's not
+        // needed for this test suite.
+        return Promise.resolve({
+          owner,
+          name,
+          canonicalName: `${owner}/${name}`,
+        } as unknown as RulesetRepository);
+      },
+    },
+  };
+});
 
 let publishEntryService: PublishEntryService;
-let mockGithubClient: Mocked<GitHubClient>;
+let mockGitClient: Mocked<GitClient>;
+let mockBcrForkGitHubClient: Mocked<GitHubClient>;
+let mockBcrGitHubClient: Mocked<GitHubClient>;
+
+const realExponentialBackoff = jest.requireActual('exponential-backoff');
+
 beforeEach(() => {
+  mockGitClient = mocked(new GitClient());
   mocked(GitHubClient).mockClear();
-  mockGithubClient = mocked(new GitHubClient({} as any));
-  publishEntryService = new PublishEntryService(mockGithubClient);
+  mockBcrForkGitHubClient = mocked(new GitHubClient({} as any));
+  mockBcrGitHubClient = mocked(new GitHubClient({} as any));
+  publishEntryService = new PublishEntryService(
+    mockGitClient,
+    mockBcrGitHubClient
+  );
 });
 
 describe('publish', () => {
@@ -30,7 +83,7 @@ describe('publish', () => {
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
 
-    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
+    expect(mockBcrGitHubClient.createPullRequest).toHaveBeenCalledWith(
       bcrFork.owner,
       branch,
       bcr.owner,
@@ -46,9 +99,10 @@ describe('publish', () => {
     const bcr = new Repository('bazel-central-registry', 'bazelbuild');
     const branch = 'branch_with_entry';
     const tag = 'v1.0.0';
+    const version = '1.0.0';
 
     await publishEntryService.publish(
-      tag,
+      version,
       bcrFork,
       bcr,
       branch,
@@ -56,7 +110,7 @@ describe('publish', () => {
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
 
-    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
+    expect(mockBcrGitHubClient.createPullRequest).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.any(String),
@@ -65,7 +119,7 @@ describe('publish', () => {
       expect.stringContaining('rules_foo'),
       expect.any(String)
     );
-    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
+    expect(mockBcrGitHubClient.createPullRequest).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.any(String),
@@ -91,7 +145,7 @@ describe('publish', () => {
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
 
-    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
+    expect(mockBcrGitHubClient.createPullRequest).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.any(String),
@@ -100,7 +154,7 @@ describe('publish', () => {
       expect.stringContaining('rules_foo'),
       expect.any(String)
     );
-    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
+    expect(mockBcrGitHubClient.createPullRequest).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.any(String),
@@ -109,7 +163,7 @@ describe('publish', () => {
       expect.stringContaining('rules_bar'),
       expect.any(String)
     );
-    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
+    expect(mockBcrGitHubClient.createPullRequest).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.any(String),
@@ -135,7 +189,7 @@ describe('publish', () => {
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
 
-    expect(mockGithubClient.createPullRequest).toHaveBeenCalledWith(
+    expect(mockBcrGitHubClient.createPullRequest).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
       expect.any(String),
@@ -154,7 +208,7 @@ describe('publish', () => {
     const branch = 'branch_with_entry';
     const tag = 'v1.0.0';
 
-    mockGithubClient.createPullRequest.mockResolvedValueOnce(4);
+    mockBcrGitHubClient.createPullRequest.mockResolvedValueOnce(4);
 
     const pr = await publishEntryService.publish(
       tag,
@@ -174,8 +228,8 @@ describe('publish', () => {
     const branch = 'branch_with_entry';
     const tag = 'v1.0.0';
 
-    mockGithubClient.createPullRequest.mockResolvedValueOnce(4);
-    mockGithubClient.enableAutoMerge.mockResolvedValueOnce(undefined);
+    mockBcrGitHubClient.createPullRequest.mockResolvedValueOnce(4);
+    mockBcrGitHubClient.enableAutoMerge.mockResolvedValueOnce(undefined);
 
     await publishEntryService.publish(
       tag,
@@ -186,7 +240,7 @@ describe('publish', () => {
       `github.com/aspect-build/rules_foo/releases/tag/${tag}`
     );
 
-    expect(mockGithubClient.enableAutoMerge).toHaveBeenCalled();
+    expect(mockBcrGitHubClient.enableAutoMerge).toHaveBeenCalled();
   });
 
   test('does not reject when enabling auto-merge fails', async () => {
@@ -195,8 +249,8 @@ describe('publish', () => {
     const branch = 'branch_with_entry';
     const tag = 'v1.0.0';
 
-    mockGithubClient.createPullRequest.mockResolvedValueOnce(4);
-    mockGithubClient.enableAutoMerge.mockRejectedValueOnce(
+    mockBcrGitHubClient.createPullRequest.mockResolvedValueOnce(4);
+    mockBcrGitHubClient.enableAutoMerge.mockRejectedValueOnce(
       'Failed to enable auto-merge!'
     );
 
@@ -210,5 +264,330 @@ describe('publish', () => {
         `github.com/aspect-build/rules_foo/releases/tag/${tag}`
       )
     ).resolves.toBe(4);
+  });
+});
+
+describe('commitEntryToNewBranch', () => {
+  test('sets the commit author to the releaser', async () => {
+    const tag = 'v1.2.3';
+    const rulesetRepo = await RulesetRepository.create('repo', 'owner', tag);
+    const bcrRepo = CANONICAL_BCR;
+    const releaser: User = {
+      name: 'Json Bearded',
+      email: 'json@bearded.ca',
+      username: 'json',
+    };
+
+    await publishEntryService.commitEntryToNewBranch(
+      rulesetRepo,
+      bcrRepo,
+      tag,
+      releaser
+    );
+
+    expect(mockGitClient.setUserNameAndEmail).toHaveBeenCalledWith(
+      bcrRepo.diskPath,
+      releaser.name,
+      releaser.email
+    );
+  });
+
+  test('sets the commit author to the publish-to-bcr bot when the release it the github-actions bot', async () => {
+    // https://github.com/bazel-contrib/publish-to-bcr/issues/120
+    const tag = 'v1.2.3';
+    const rulesetRepo = await RulesetRepository.create('repo', 'owner', tag);
+    const bcrRepo = CANONICAL_BCR;
+    const releaser = UserService.fromGitHubUser(
+      GitHubClient.GITHUB_ACTIONS_BOT
+    );
+    const botUser: Partial<GitHubUser> = {
+      name: 'publish-to-bcr',
+      login: 'publish-to-bcr[bot]',
+      email: `12345+"publish-to-bcr[bot]@users.noreply.github.com`,
+    };
+    const botApp = { slug: 'publish-to-bcr' } as GitHubApp;
+
+    mockBcrGitHubClient.getApp.mockResolvedValue(botApp);
+    mockBcrGitHubClient.getBotAppUser.mockResolvedValue(botUser as GitHubUser);
+
+    await publishEntryService.commitEntryToNewBranch(
+      rulesetRepo,
+      bcrRepo,
+      tag,
+      releaser
+    );
+
+    expect(mockBcrGitHubClient.getApp).toHaveBeenCalled();
+    expect(mockBcrGitHubClient.getBotAppUser).toHaveBeenCalledWith(botApp);
+
+    expect(mockGitClient.setUserNameAndEmail).toHaveBeenCalledWith(
+      bcrRepo.diskPath,
+      botUser.name,
+      botUser.email
+    );
+  });
+
+  test('checks out a new branch on the bcr repo', async () => {
+    const tag = 'v1.2.3';
+    const rulesetRepo = await RulesetRepository.create('repo', 'owner', tag);
+    const bcrRepo = CANONICAL_BCR;
+    const releaser: User = {
+      name: 'Json Bearded',
+      email: 'json@bearded.ca',
+      username: 'json',
+    };
+
+    await publishEntryService.commitEntryToNewBranch(
+      rulesetRepo,
+      bcrRepo,
+      tag,
+      releaser
+    );
+
+    expect(mockGitClient.checkoutNewBranchFromHead).toHaveBeenCalledWith(
+      bcrRepo.diskPath,
+      expect.any(String)
+    );
+  });
+
+  test('branch contains the repo name and release tag', async () => {
+    const tag = 'v1.2.3';
+    const rulesetRepo = await RulesetRepository.create('repo', 'owner', tag);
+    const bcrRepo = CANONICAL_BCR;
+    const releaser: User = {
+      name: 'Json Bearded',
+      email: 'json@bearded.ca',
+      username: 'json',
+    };
+
+    await publishEntryService.commitEntryToNewBranch(
+      rulesetRepo,
+      bcrRepo,
+      tag,
+      releaser
+    );
+
+    expect(mockGitClient.checkoutNewBranchFromHead).toHaveBeenCalledTimes(1);
+    expect(mockGitClient.checkoutNewBranchFromHead).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining(rulesetRepo.canonicalName)
+    );
+    expect(mockGitClient.checkoutNewBranchFromHead).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining(tag)
+    );
+  });
+
+  test('returns the created branch name', async () => {
+    const tag = 'v1.2.3';
+    const rulesetRepo = await RulesetRepository.create('repo', 'owner', tag);
+    const bcrRepo = CANONICAL_BCR;
+    const releaser: User = {
+      name: 'Json Bearded',
+      email: 'json@bearded.ca',
+      username: 'json',
+    };
+
+    const returnedBranch = await publishEntryService.commitEntryToNewBranch(
+      rulesetRepo,
+      bcrRepo,
+      tag,
+      releaser
+    );
+    const createdBranch =
+      mockGitClient.checkoutNewBranchFromHead.mock.calls[0][1];
+
+    expect(returnedBranch).toEqual(createdBranch);
+  });
+
+  test('commit message contains the repo name and release tag', async () => {
+    const tag = 'v1.2.3';
+    const rulesetRepo = await RulesetRepository.create('repo', 'owner', tag);
+    const bcrRepo = CANONICAL_BCR;
+    const releaser: User = {
+      name: 'Json Bearded',
+      email: 'json@bearded.ca',
+      username: 'json',
+    };
+
+    await publishEntryService.commitEntryToNewBranch(
+      rulesetRepo,
+      bcrRepo,
+      tag,
+      releaser
+    );
+
+    expect(mockGitClient.commitChanges).toHaveBeenCalledTimes(1);
+    expect(mockGitClient.commitChanges).toHaveBeenCalledWith(
+      bcrRepo.diskPath,
+      expect.stringContaining(rulesetRepo.canonicalName)
+    );
+    expect(mockGitClient.commitChanges).toHaveBeenCalledWith(
+      bcrRepo.diskPath,
+      expect.stringContaining(tag)
+    );
+  });
+});
+
+describe('pushEntryToFork', () => {
+  beforeEach(() => {
+    // Reduce the exponential-backoff delay to 0 for tests
+    (backOff as unknown as jest.SpyInstance).mockImplementation(
+      (request: () => Promise<void>, options?: BackoffOptions) =>
+        realExponentialBackoff.backOff(request, {
+          ...options,
+          startingDelay: 0,
+        })
+    );
+  });
+
+  test('acquires an authenticated remote url for the bcr fork', async () => {
+    const bcrRepo = CANONICAL_BCR;
+    const bcrForkRepo = new Repository('bazel-central-registry', 'aspect');
+    const branchName = `repo/owner@v1.2.3`;
+
+    await publishEntryService.pushEntryToFork(
+      bcrForkRepo,
+      bcrRepo,
+      branchName,
+      mockBcrForkGitHubClient
+    );
+    expect(
+      mockBcrForkGitHubClient.getAuthenticatedRemoteUrl
+    ).toHaveBeenCalledWith(bcrForkRepo.owner, bcrForkRepo.name);
+  });
+
+  test('adds a remote with the authenticated url for the fork to the local bcr repo', async () => {
+    const bcrRepo = CANONICAL_BCR;
+    const bcrForkRepo = new Repository('bazel-central-registry', 'aspect');
+    const branchName = `repo/owner@v1.2.3`;
+    const authenticatedUrl = randomUUID();
+
+    mockBcrForkGitHubClient.getAuthenticatedRemoteUrl.mockReturnValueOnce(
+      Promise.resolve(authenticatedUrl)
+    );
+
+    await publishEntryService.pushEntryToFork(
+      bcrForkRepo,
+      bcrRepo,
+      branchName,
+      mockBcrForkGitHubClient
+    );
+    expect(mockGitClient.addRemote).toHaveBeenCalledWith(
+      bcrRepo.diskPath,
+      expect.any(String),
+      authenticatedUrl
+    );
+  });
+
+  test("named the authenticated remote 'authed-fork'", async () => {
+    const bcrRepo = CANONICAL_BCR;
+    const bcrForkRepo = new Repository('bazel-central-registry', 'aspect');
+    const branchName = `repo/owner@v1.2.3`;
+    const authenticatedUrl = randomUUID();
+
+    mockBcrForkGitHubClient.getAuthenticatedRemoteUrl.mockReturnValueOnce(
+      Promise.resolve(authenticatedUrl)
+    );
+
+    await publishEntryService.pushEntryToFork(
+      bcrForkRepo,
+      bcrRepo,
+      branchName,
+      mockBcrForkGitHubClient
+    );
+    expect(mockGitClient.addRemote).toHaveBeenCalledWith(
+      expect.any(String),
+      'authed-fork',
+      expect.any(String)
+    );
+  });
+
+  test('does not re-add the remote if it already exists', async () => {
+    const bcrRepo = CANONICAL_BCR;
+    const bcrForkRepo = new Repository('bazel-central-registry', 'aspect');
+    const branchName = `repo/owner@v1.2.3`;
+    const authenticatedUrl = randomUUID();
+
+    mockGitClient.hasRemote.mockReturnValueOnce(Promise.resolve(true));
+    mockBcrForkGitHubClient.getAuthenticatedRemoteUrl.mockReturnValueOnce(
+      Promise.resolve(authenticatedUrl)
+    );
+
+    await publishEntryService.pushEntryToFork(
+      bcrForkRepo,
+      bcrRepo,
+      branchName,
+      mockBcrForkGitHubClient
+    );
+    expect(mockGitClient.addRemote).not.toHaveBeenCalled();
+  });
+
+  test('pushes the entry branch to the fork using the authorized remote', async () => {
+    const bcrRepo = CANONICAL_BCR;
+    const bcrForkRepo = new Repository('bazel-central-registry', 'aspect');
+    const branchName = `repo/owner@v1.2.3`;
+
+    await publishEntryService.pushEntryToFork(
+      bcrForkRepo,
+      bcrRepo,
+      branchName,
+      mockBcrForkGitHubClient
+    );
+
+    expect(mockGitClient.push).toHaveBeenCalledWith(
+      bcrRepo.diskPath,
+      'authed-fork',
+      branchName
+    );
+  });
+
+  test('retries 5 times if it fails', async () => {
+    const bcrRepo = CANONICAL_BCR;
+    const bcrForkRepo = new Repository('bazel-central-registry', 'aspect');
+    const branchName = `repo/owner@v1.2.3`;
+
+    (backOff as unknown as jest.SpyInstance).mockImplementation(
+      (request: () => Promise<any>, options?: BackoffOptions) => {
+        return realExponentialBackoff.backOff(request, {
+          ...options,
+          startingDelay: 0,
+        });
+      }
+    );
+
+    mockGitClient.push
+      .mockRejectedValueOnce(new Error('failed push'))
+      .mockRejectedValueOnce(new Error('failed push'))
+      .mockRejectedValueOnce(new Error('failed push'))
+      .mockRejectedValueOnce(new Error('failed push'))
+      .mockResolvedValueOnce(undefined);
+
+    await publishEntryService.pushEntryToFork(
+      bcrForkRepo,
+      bcrRepo,
+      branchName,
+      mockBcrForkGitHubClient
+    );
+
+    expect(mockGitClient.push).toHaveBeenCalledTimes(5);
+  });
+
+  test('fails after the 5th retry', async () => {
+    const bcrRepo = CANONICAL_BCR;
+    const bcrForkRepo = new Repository('bazel-central-registry', 'aspect');
+    const branchName = `repo/owner@v1.2.3`;
+
+    mockGitClient.push.mockRejectedValue(new Error('failed push'));
+
+    await expect(
+      publishEntryService.pushEntryToFork(
+        bcrForkRepo,
+        bcrRepo,
+        branchName,
+        mockBcrForkGitHubClient
+      )
+    ).rejects.toThrow();
+    expect(mockGitClient.push).toHaveBeenCalledTimes(5);
   });
 });

--- a/src/domain/publish-entry.ts
+++ b/src/domain/publish-entry.ts
@@ -1,12 +1,95 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
 
+import { Inject, Injectable } from '@nestjs/common';
+import { backOff } from 'exponential-backoff';
+
+import { GitClient } from '../infrastructure/git.js';
 import { GitHubClient } from '../infrastructure/github.js';
 import { Repository } from './repository.js';
 import { RulesetRepository } from './ruleset-repository.js';
+import { User, UserService } from './user.js';
 
 @Injectable()
 export class PublishEntryService {
-  constructor(@Inject('bcrGitHubClient') private githubClient: GitHubClient) {}
+  constructor(
+    private readonly gitClient: GitClient,
+    @Inject('bcrGitHubClient') private bcrGitHubClient: GitHubClient
+  ) {}
+
+  public async commitEntryToNewBranch(
+    rulesetRepo: Repository,
+    bcrRepo: Repository,
+    tag: string,
+    releaser: User
+  ): Promise<string> {
+    const repoAndVersion = `${rulesetRepo.canonicalName}@${tag}`;
+    const branchName = `${repoAndVersion}-${randomBytes(4).toString('hex')}`;
+
+    let commitAuthor: Partial<User> = releaser;
+    if (UserService.isGitHubActionsBot(releaser)) {
+      const botApp = await this.bcrGitHubClient.getApp();
+      const botAppUser = await this.bcrGitHubClient.getBotAppUser(botApp);
+
+      commitAuthor = {
+        name: botAppUser.name,
+        email: botAppUser.email,
+      };
+    }
+
+    await this.gitClient.setUserNameAndEmail(
+      bcrRepo.diskPath,
+      commitAuthor.name,
+      commitAuthor.email
+    );
+    console.log(bcrRepo.diskPath);
+    console.log(branchName);
+    await this.gitClient.checkoutNewBranchFromHead(
+      bcrRepo.diskPath,
+      branchName
+    );
+    await this.gitClient.commitChanges(
+      bcrRepo.diskPath,
+      `Publish ${repoAndVersion}`
+    );
+
+    return branchName;
+  }
+
+  public async pushEntryToFork(
+    bcrForkRepo: Repository,
+    bcr: Repository,
+    branch: string,
+    githubClient: GitHubClient
+  ): Promise<void> {
+    const authenticatedRemoteUrl = await githubClient.getAuthenticatedRemoteUrl(
+      bcrForkRepo.owner,
+      bcrForkRepo.name
+    );
+
+    if (!(await this.gitClient.hasRemote(bcr.diskPath, 'authed-fork'))) {
+      await this.gitClient.addRemote(
+        bcr.diskPath,
+        'authed-fork',
+        authenticatedRemoteUrl
+      );
+    }
+
+    if (process.env.INTEGRATION_TESTING) {
+      // It is too difficult to mock the responses to `git push` when
+      // not using a real git server. Just push to the original remote,
+      // which, during testing, is just a local repo on disk, so that
+      // we can examine the result.
+      await this.gitClient.push(bcr.diskPath, 'origin', branch);
+      return;
+    }
+
+    await backOff(
+      () => this.gitClient.push(bcr.diskPath, 'authed-fork', branch),
+      {
+        numOfAttempts: 5,
+      }
+    );
+  }
 
   public async publish(
     tag: string,
@@ -17,8 +100,7 @@ export class PublishEntryService {
     releaseUrl: string
   ): Promise<number> {
     const version = RulesetRepository.getVersionFromTag(tag);
-
-    const pullNumber = await this.githubClient.createPullRequest(
+    const pullNumber = await this.bcrGitHubClient.createPullRequest(
       bcrForkRepo.owner,
       branch,
       bcr.owner,
@@ -32,7 +114,11 @@ _Automated by [Publish to BCR](https://github.com/apps/publish-to-bcr)_`
     );
 
     try {
-      await this.githubClient.enableAutoMerge(bcr.owner, bcr.name, pullNumber);
+      await this.bcrGitHubClient.enableAutoMerge(
+        bcr.owner,
+        bcr.name,
+        pullNumber
+      );
     } catch {
       console.error(
         `Error: Failed to enable auto-merge on pull request github.com/${bcr.canonicalName}/pull/${pullNumber}.`


### PR DESCRIPTION
Move the "commit entry" and "push to fork" logic out of the `CreateEntryService` into the `PublishEntryService`. This isolates the entry file creation domain logic so that it's easier to inject and reuse in the CLI.