### PR TITLE
feat(cli): create bcr entry from command

### DIFF
--- a/src/application/cli/BUILD.bazel
+++ b/src/application/cli/BUILD.bazel
@@ -35,6 +35,7 @@ ts_project(
         "//:node_modules/@types/jest",  # keep
         "//:node_modules/@types/yargs",
         "//:node_modules/yargs",
+        "//src/domain",
     ],
 )
 

--- a/src/application/cli/app.module.ts
+++ b/src/application/cli/app.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 
+import { CreateEntryService } from '../../domain/create-entry.js';
 import { CreateEntryCommand } from './create-entry-command.js';
 
 @Module({
-  providers: [CreateEntryCommand],
+  providers: [CreateEntryCommand, CreateEntryService],
 })
 export class AppModule {}

--- a/src/application/cli/yargs.spec.ts
+++ b/src/application/cli/yargs.spec.ts
@@ -1,15 +1,17 @@
 import { Argv } from 'yargs';
 
+import { CreateEntryService } from '../../domain/create-entry.js';
 import { CreateEntryCommand } from './create-entry-command.js';
 import { ApplicationArgs, createParser } from './yargs.js';
 
 jest.mock('./create-entry-command.js');
+jest.mock('../../domain/create-entry.js');
 
 describe('createParser', () => {
   let parser: Argv<ApplicationArgs>;
 
   beforeEach(() => {
-    parser = createParser(new CreateEntryCommand());
+    parser = createParser(new CreateEntryCommand(new CreateEntryService()));
   });
 
   test('displays --help', async () => {
@@ -31,20 +33,102 @@ describe('createParser', () => {
 
   describe('create-entry', () => {
     test('missing --templates-dir', async () => {
-      expect(() => parser.parse('create-entry')).toThrow(
-        'Missing required argument: templates-dir'
-      );
+      expect(() =>
+        parser.parse(
+          'create-entry --local-registry /path/to/bcr --module-version 1.0.0'
+        )
+      ).toThrow('Missing required argument: templates-dir');
     });
 
     test('missing --templates-dir arg', () => {
-      expect(() => parser.parse('create-entry --templates-dir')).toThrow(
-        'Not enough arguments following: templates-dir'
-      );
+      expect(() =>
+        parser.parse(
+          'create-entry --local-registry /path/to/bcr --module-version 1.0.0 --templates-dir'
+        )
+      ).toThrow('Not enough arguments following: templates-dir');
     });
 
     test('parses --templates-dir', async () => {
-      const args = await parser.parse('create-entry --templates-dir .bcr');
+      const args = await parser.parse(
+        'create-entry --templates-dir .bcr --local-registry /path/to/bcr --module-version 1.0.0'
+      );
       expect(args.templatesDir).toEqual('.bcr');
+    });
+
+    test('missing --module-version', () => {
+      expect(() =>
+        parser.parse(
+          'create-entry --templates-dir .bcr --local-registry /path/to/bcr'
+        )
+      ).toThrow('Missing required argument: module-version');
+    });
+
+    test('missing --module-version arg', () => {
+      expect(() =>
+        parser.parse(
+          'create-entry --templates-dir .bcr --local-registry /path/to/bcr --tag v1.0.0 --module-version'
+        )
+      ).toThrow('Not enough arguments following: module-version');
+    });
+
+    test('parses --module-version', async () => {
+      const args = await parser.parse(
+        'create-entry --templates-dir .bcr --local-registry /path/to/bcr --module-version 1.0.0'
+      );
+      expect(args.moduleVersion).toEqual('1.0.0');
+    });
+
+    test('missing --tag arg', () => {
+      expect(() =>
+        parser.parse(
+          'create-entry --templates-dir .bcr --local-registry /path/to/bcr --tag'
+        )
+      ).toThrow('Not enough arguments following: tag');
+    });
+
+    test('parses --tag', async () => {
+      const args = await parser.parse(
+        'create-entry --templates-dir .bcr --local-registry /path/to/bcr --module-version 1.0.0 --tag v1.0.0'
+      );
+      expect(args.tag).toEqual('v1.0.0');
+    });
+
+    test('missing --local-registry', () => {
+      expect(() =>
+        parser.parse(
+          'create-entry --templates-dir .bcr --tag v1.0.0 --module-version 1.0.0'
+        )
+      ).toThrow('Missing required argument: local-registry');
+    });
+
+    test('missing --local-registry arg', () => {
+      expect(() =>
+        parser.parse(
+          'create-entry --templates-dir .bcr --tag v1.0.0  --module-version 1.0.0 --local-registry'
+        )
+      ).toThrow('Not enough arguments following: local-registry');
+    });
+
+    test('parses --local-registry', async () => {
+      const args = await parser.parse(
+        'create-entry --templates-dir .bcr --local-registry /path/to/bcr --module-version 1.0.0'
+      );
+      expect(args.localRegistry).toEqual('/path/to/bcr');
+    });
+
+    test('missing --github-repository arg', () => {
+      expect(() =>
+        parser.parse(
+          'create-entry --templates-dir .bcr --tag v1.0.0 --local-registry /path/to/bcr --github-repository'
+        )
+      ).toThrow('Not enough arguments following: github-repository');
+    });
+
+    test('parses --github-repository', async () => {
+      const args = await parser.parse(
+        'create-entry --templates-dir .bcr --module-version 1.0.0 --github-repository foo/bar --local-registry /path/to/bcr'
+      );
+      expect(args.githubRepository).toEqual('foo/bar');
     });
   });
 });

--- a/src/application/cli/yargs.ts
+++ b/src/application/cli/yargs.ts
@@ -4,6 +4,10 @@ import { hideBin } from 'yargs/helpers';
 import { CreateEntryCommand } from './create-entry-command';
 
 export interface CreateEntryArgs {
+  githubRepository?: string;
+  moduleVersion: string;
+  localRegistry: string;
+  tag: string;
   templatesDir: string;
 }
 
@@ -22,9 +26,36 @@ export function createParser(
       'create-entry',
       'Create a new module version entry for the BCR',
       (yargs) => {
+        yargs.option('github-repository', {
+          describe:
+            'GitHub repository for the module being published. Used to substititue the OWNER and REPO vars into the source template.',
+          type: 'string',
+          required: false,
+          requiresArg: true,
+        });
+        yargs.option('local-registry', {
+          describe:
+            'Path to a locally checked out registry where the entry files will be created.',
+          type: 'string',
+          required: true,
+          requiresArg: true,
+        });
+        yargs.option('module-version', {
+          describe: 'The module version to publish to the registry.',
+          type: 'string',
+          required: true,
+          requiresArg: true,
+        });
+        yargs.option('tag', {
+          describe:
+            "Tag of the the module repository's release. Used for substitution in the source template.",
+          type: 'string',
+          required: false,
+          requiresArg: true,
+        });
         yargs.option('templates-dir', {
           describe:
-            'Directory containing a config file, BCR templates, and other release files: config.yml, source.template.json, metadata.template.json, presubmit.yaml. Equivalent to the .bcr directory required by the legacy GitHub app.',
+            'Directory containing BCR release template files: metadata.template.json, source.template.json, presubmit.yaml, patches/. Equivalent to the .bcr directory required by the legacy GitHub app.',
           type: 'string',
           required: true,
           requiresArg: true,

--- a/src/domain/repository.spec.ts
+++ b/src/domain/repository.spec.ts
@@ -14,6 +14,27 @@ describe('fromCanonicalName', () => {
     expect(repository.owner).toEqual('foo');
     expect(repository.name).toEqual('bar');
   });
+
+  test('throws when not a canonical name', () => {
+    expect(() => Repository.fromCanonicalName('foobar')).toThrowWithMessage(
+      Error,
+      "Invalid GitHub repository canonical name 'foobar'; expected format owner/repo"
+    );
+  });
+
+  test('throws when the owner is missing', () => {
+    expect(() => Repository.fromCanonicalName('/bar')).toThrowWithMessage(
+      Error,
+      "Invalid GitHub repository canonical name '/bar'; expected format owner/repo"
+    );
+  });
+
+  test('throws when the repo is missing', () => {
+    expect(() => Repository.fromCanonicalName('foo/')).toThrowWithMessage(
+      Error,
+      "Invalid GitHub repository canonical name 'foo/'; expected format owner/repo"
+    );
+  });
 });
 
 describe('canonicalName', () => {

--- a/src/domain/source-template.spec.ts
+++ b/src/domain/source-template.spec.ts
@@ -80,7 +80,12 @@ describe('substitute', () => {
     );
     expect(sourceTemplate.stripPrefix).toEqual('{REPO}-{VERSION}');
 
-    sourceTemplate.substitute('foo', 'bar', 'v1.2.3', '1.2.3');
+    sourceTemplate.substitute({
+      OWNER: 'foo',
+      REPO: 'bar',
+      TAG: 'v1.2.3',
+      VERSION: '1.2.3',
+    });
 
     sourceTemplate.save('source.json');
 
@@ -186,7 +191,12 @@ describe('url', () => {
       'https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz'
     );
 
-    sourceTemplate.substitute('foo', 'bar', 'v1.2.3', '1.2.3');
+    sourceTemplate.substitute({
+      OWNER: 'foo',
+      REPO: 'bar',
+      TAG: 'v1.2.3',
+      VERSION: '1.2.3',
+    });
 
     expect(sourceTemplate.url).toEqual(
       'https://github.com/foo/bar/archive/refs/tags/v1.2.3.tar.gz'
@@ -200,7 +210,12 @@ describe('stripPrefix', () => {
 
     expect(sourceTemplate.stripPrefix).toEqual('{REPO}-{VERSION}');
 
-    sourceTemplate.substitute('foo', 'bar', 'v1.2.3', '1.2.3');
+    sourceTemplate.substitute({
+      OWNER: 'foo',
+      REPO: 'bar',
+      TAG: 'v1.2.3',
+      VERSION: '1.2.3',
+    });
 
     expect(sourceTemplate.stripPrefix).toEqual('bar-1.2.3');
   });
@@ -211,7 +226,12 @@ describe('stripPrefix', () => {
 
     expect(sourceTemplate.stripPrefix).toEqual('');
 
-    sourceTemplate.substitute('foo', 'bar', 'v1.2.3', '1.2.3');
+    sourceTemplate.substitute({
+      OWNER: 'foo',
+      REPO: 'bar',
+      TAG: 'v1.2.3',
+      VERSION: '1.2.3',
+    });
 
     expect(sourceTemplate.stripPrefix).toEqual('');
   });

--- a/src/domain/source-template.ts
+++ b/src/domain/source-template.ts
@@ -6,6 +6,8 @@ export class InvalidSourceTemplateError extends Error {
   }
 }
 
+export type SubstitutableVar = 'OWNER' | 'REPO' | 'TAG' | 'VERSION';
+
 export class SourceTemplate {
   private sourceJson: Record<string, unknown>;
 
@@ -38,37 +40,25 @@ export class SourceTemplate {
   }
 
   // Substitute variables into the templated source.json
-  public substitute(
-    repoOwner: string,
-    repoName: string,
-    tag: string,
-    version: string
-  ) {
+  public substitute(vars: Partial<Record<SubstitutableVar, string>>) {
     for (const prop of ['url', 'strip_prefix'].filter(
       (prop) => prop in this.sourceJson
     )) {
       this.sourceJson[prop] = this.replaceVariables(
         this.sourceJson[prop] as string,
-        repoOwner,
-        repoName,
-        tag,
-        version
+        vars
       );
     }
   }
 
   private replaceVariables(
     str: string,
-    repoOwner: string,
-    repoName: string,
-    tag: string,
-    version: string
+    vars: Partial<Record<SubstitutableVar, string>>
   ) {
-    return str
-      .replace(/{OWNER}/g, repoOwner)
-      .replace(/{REPO}/g, repoName)
-      .replace(/{VERSION}/g, version)
-      .replace(/{TAG}/g, tag);
+    for (const key of Object.keys(vars)) {
+      str = str.replaceAll(`{${key}}`, vars[key as SubstitutableVar]);
+    }
+    return str;
   }
 
   public setIntegrityHash(integrityHash: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "module": "es2020",
     "target": "es2020",
+    "lib": ["es2021", "dom"],
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
This creates a new set of entry files for a module release in a locally checked out registry. In addition:
- Refactored the `CreateEntryService` to work for both the app and the cli
- No longer loading the config file for the cli as the only options in there are only needed by the app
- Multi-module entries are already supported by running the cli multiple times and changing the `--templates-dir`