### PR TITLE
feat: add an attestations.json substitutable template

### DIFF
--- a/e2e/cli/BUILD.bazel
+++ b/e2e/cli/BUILD.bazel
@@ -8,6 +8,7 @@ bats_test(
     ],
     data = [
         "//e2e/fixtures",
+        "//e2e/fixtures:attestations",
         "//e2e/fixtures:versioned",
         "//e2e/fixtures:zip",
         "//src/application/cli:bundle",

--- a/e2e/fixtures/BUILD.bazel
+++ b/e2e/fixtures/BUILD.bazel
@@ -2,6 +2,12 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 load(":fixture.bzl", "fixture_archive")
 
 fixture_archive(
+    name = "attestations",
+    archive = "tar",
+    prefix = "attestations-1.0.0",
+)
+
+fixture_archive(
     name = "empty-prefix",
     archive = "tar",
     prefix = None,

--- a/e2e/fixtures/attestations/.bcr/attestations.template.json
+++ b/e2e/fixtures/attestations/.bcr/attestations.template.json
@@ -1,0 +1,17 @@
+{
+  "types": ["https://slsa.dev/provenance/v1"],
+  "attestations": {
+    "source.json": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/source.json.intoto.jsonl",
+      "integrity": ""
+    },
+    "MODULE.bazel": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/MODULE.bazel.intoto.jsonl",
+      "integrity": ""
+    },
+    "{REPO}-{TAG}.tar.gz.intoto.jsonl": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz.intoto.jsonl",
+      "integrity": ""
+    }
+  }
+}

--- a/e2e/fixtures/attestations/.bcr/metadata.template.json
+++ b/e2e/fixtures/attestations/.bcr/metadata.template.json
@@ -1,0 +1,13 @@
+{
+  "homepage": "https://github.com/testorg/attestations",
+  "maintainers": [
+    {
+      "name": "Foo McBar",
+      "email": "foo@test.org",
+      "github": "foobar"
+    }
+  ],
+  "repository": ["github:testorg/attestations"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/e2e/fixtures/attestations/.bcr/presubmit.yml
+++ b/e2e/fixtures/attestations/.bcr/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/e2e/fixtures/attestations/.bcr/source.template.json
+++ b/e2e/fixtures/attestations/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}

--- a/e2e/fixtures/attestations/MODULE.bazel
+++ b/e2e/fixtures/attestations/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "attestations",
+    version = "1.0.0",
+)

--- a/e2e/fixtures/attestations/README.md
+++ b/e2e/fixtures/attestations/README.md
@@ -1,0 +1,1 @@
+Ruleset repo with `attestations.template.json`.

--- a/e2e/github-webhook/BUILD.bazel
+++ b/e2e/github-webhook/BUILD.bazel
@@ -7,6 +7,7 @@ ts_project(
     srcs = ["e2e.spec.ts"],
     data = [
         "//e2e/fixtures",
+        "//e2e/fixtures:attestations",
         "//e2e/fixtures:empty-prefix",
         "//e2e/fixtures:fixed-releaser",
         "//e2e/fixtures:multi-module",

--- a/e2e/github-webhook/__snapshots__/e2e.spec.js.snap
+++ b/e2e/github-webhook/__snapshots__/e2e.spec.js.snap
@@ -257,6 +257,87 @@ modules/submodule/metadata.json
 "
 `;
 
+exports[`e2e tests [snapshot] ruleset with attestations 1`] = `
+"----------------------------------------------------
+modules/attestations/1.0.0/MODULE.bazel
+----------------------------------------------------
+module(
+    name = "attestations",
+    version = "1.0.0",
+)
+
+----------------------------------------------------
+modules/attestations/1.0.0/attestations.json
+----------------------------------------------------
+{
+    "types": [
+        "https://slsa.dev/provenance/v1"
+    ],
+    "attestations": {
+        "source.json": {
+            "url": "https://github.com/testorg/attestations/releases/download/v1.0.0/source.json.intoto.jsonl",
+            "integrity": "sha256-uKDY/T+tSAasJP4TVUoB8zHqM8IGh8IJaOiN/4kJUDM="
+        },
+        "MODULE.bazel": {
+            "url": "https://github.com/testorg/attestations/releases/download/v1.0.0/MODULE.bazel.intoto.jsonl",
+            "integrity": "sha256-IXNI7+fdDXNXwbhf/tYlRHWg6g0SzZLi3Va2bnDfEM0="
+        },
+        "attestations-v1.0.0.tar.gz.intoto.jsonl": {
+            "url": "https://github.com/testorg/attestations/releases/download/v1.0.0/attestations-v1.0.0.tar.gz.intoto.jsonl",
+            "integrity": "sha256-F8+mmnlCygeJk5x/E89lVtxmXvxyfzUe/vb+3cmrTGs="
+        }
+    }
+}
+
+----------------------------------------------------
+modules/attestations/1.0.0/presubmit.yml
+----------------------------------------------------
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: \${{ platform }}
+      bazel: \${{ bazel }}
+      test_targets:
+        - "//..."
+
+----------------------------------------------------
+modules/attestations/1.0.0/source.json
+----------------------------------------------------
+{
+    "integrity": "sha256-R+12jZIR/44X7Tphnee6gygY9XJlYlPCghh1nmsvPHY=",
+    "strip_prefix": "attestations-1.0.0",
+    "url": "https://github.com/testorg/attestations/releases/download/v1.0.0/attestations-v1.0.0.tar.gz"
+}
+
+----------------------------------------------------
+modules/attestations/metadata.json
+----------------------------------------------------
+{
+    "homepage": "https://github.com/testorg/attestations",
+    "maintainers": [
+        {
+            "name": "Foo McBar",
+            "email": "foo@test.org",
+            "github": "foobar"
+        }
+    ],
+    "repository": [
+        "github:testorg/attestations"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}
+
+"
+`;
+
 exports[`e2e tests [snapshot] ruleset with tarball release archive 1`] = `
 "----------------------------------------------------
 modules/tarball/1.0.0/MODULE.bazel

--- a/e2e/github-webhook/helpers/fixture.ts
+++ b/e2e/github-webhook/helpers/fixture.ts
@@ -10,6 +10,7 @@ export const PREPARED_FIXTURES_PATH = fs.mkdtempSync(
 );
 
 export enum Fixture {
+  Attestations = 'attestations',
   EmptyPrefix = 'empty-prefix',
   FixedReleaser = 'fixed-releaser',
   MultiModule = 'multi-module',

--- a/e2e/github-webhook/stubs/fake-github.ts
+++ b/e2e/github-webhook/stubs/fake-github.ts
@@ -119,7 +119,7 @@ export class FakeGitHub implements StubbedServer {
     this.ownedRepos.get(owner)!.push(repo);
   }
 
-  public async mockReleaseArchive(
+  public async mockReleaseArtifact(
     urlPath: string,
     filepath: string
   ): Promise<void> {

--- a/src/application/cli/create-entry-command.ts
+++ b/src/application/cli/create-entry-command.ts
@@ -5,6 +5,12 @@ import treeNodeCli from 'tree-node-cli';
 import { ArgumentsCamelCase } from 'yargs';
 
 import {
+  AttestationDownloadError,
+  AttestationsTemplate,
+  AttestationsTemplateError,
+  UnsubstitutedAttestationVarsError,
+} from '../../domain/attestations-template.js';
+import {
   CreateEntryService,
   VersionAlreadyPublishedError,
 } from '../../domain/create-entry.js';
@@ -19,11 +25,11 @@ import {
 import { Repository } from '../../domain/repository.js';
 import {
   SourceTemplate,
-  UnsubstitutedVarsError,
+  UnsubstitutedVarsError as UnsubstitutedSourceVarsError,
 } from '../../domain/source-template.js';
 import { SourceTemplateError } from '../../domain/source-template.js';
-import { CreateEntryArgs } from './yargs.js';
 import { SubstitutableVar } from '../../domain/substitution.js';
+import { CreateEntryArgs } from './yargs.js';
 
 export interface CreateEntryCommandOutput {
   moduleName: string;
@@ -42,18 +48,29 @@ export class CreateEntryCommand {
       args.templatesDir,
       'source.template.json'
     );
+    const attestationsTemplatePath = path.join(
+      args.templatesDir,
+      'attestations.template.json'
+    );
     try {
       const metadataTemplate = new MetadataFile(
         path.join(args.templatesDir, 'metadata.template.json')
       );
       const sourceTemplate = new SourceTemplate(sourceTemplatePath);
+      const attestationsTemplate = AttestationsTemplate.tryLoad(
+        attestationsTemplatePath
+      );
       const presubmitPath = path.join(args.templatesDir, 'presubmit.yml');
       const patchesPath = path.join(args.templatesDir, 'patches');
 
-      sourceTemplate.substitute({
+      const substitutions = {
         ...ghRepoSubstitutions(args.githubRepository),
         ...(args.tag ? { TAG: args.tag } : {}),
-      });
+      };
+      sourceTemplate.substitute(substitutions);
+      if (attestationsTemplate) {
+        attestationsTemplate.substitute(substitutions);
+      }
 
       console.error(
         `Creating entry for module version ${args.moduleVersion} in ${args.localRegistry}`
@@ -65,7 +82,8 @@ export class CreateEntryCommand {
         presubmitPath,
         patchesPath,
         args.localRegistry,
-        args.moduleVersion
+        args.moduleVersion,
+        attestationsTemplate
       );
 
       console.error(
@@ -94,13 +112,17 @@ export class CreateEntryCommand {
         )
       );
     } catch (e) {
-      this.handleErrorAndExit(sourceTemplatePath, e);
+      this.handleErrorAndExit(sourceTemplatePath, attestationsTemplatePath, e);
     }
 
     return Promise.resolve(null);
   }
 
-  private handleErrorAndExit(sourceTemplatePath: string, e: Error): void {
+  private handleErrorAndExit(
+    sourceTemplatePath: string,
+    attestationsTemplatePath: string,
+    e: Error
+  ): void {
     if (e instanceof MetadataFileError) {
       console.error(
         `Failed to read metadata template at ${e.path}: ${e.message}`
@@ -109,7 +131,7 @@ export class CreateEntryCommand {
       console.error(
         `Failed to read source template at ${e.path}: ${e.message}`
       );
-    } else if (e instanceof UnsubstitutedVarsError) {
+    } else if (e instanceof UnsubstitutedSourceVarsError) {
       console.error(
         `Source template ${e.path} has unsubstituted variables ${Array.from(e.unsubstituted).join(',')}`
       );
@@ -147,6 +169,34 @@ export class CreateEntryCommand {
     } else if (e instanceof VersionAlreadyPublishedError) {
       console.error(
         `The local registry already has version ${e.version} of module ${e.moduleName}. Aborting.`
+      );
+    } else if (e instanceof AttestationsTemplateError) {
+      console.error(
+        `Failed to read attestations template at ${e.path}: ${e.message}`
+      );
+    } else if (e instanceof UnsubstitutedAttestationVarsError) {
+      console.error(
+        `Attestations template ${e.path} has unsubstituted variables ${Array.from(e.unsubstituted).join(',')}`
+      );
+      if (
+        e.unsubstituted.has(SubstitutableVar.OWNER) ||
+        e.unsubstituted.has(SubstitutableVar.REPO)
+      ) {
+        console.error(
+          'Did you forget to pass --github-repository to substitute the OWNER and REPO variables?'
+        );
+      }
+      if (e.unsubstituted.has(SubstitutableVar.TAG)) {
+        console.error(
+          'Did you forget to pass --tag to substitute the TAG variable?'
+        );
+      }
+    } else if (e instanceof AttestationDownloadError) {
+      console.error(
+        `Failed to download attestation ${e.url}; received status code ${e.statusCode}`
+      );
+      console.error(
+        `Double check that the url in ${attestationsTemplatePath} is correct and that the attestation has been uploaded by the time this command is run. `
       );
     } else {
       throw e;

--- a/src/application/release-event-handler.ts
+++ b/src/application/release-event-handler.ts
@@ -75,10 +75,17 @@ export class ReleaseEventHandler {
           console.error(`Creating BCR entry for module root '${moduleRoot}'`);
 
           const sourceTemplate = rulesetRepo.sourceTemplate(moduleRoot);
+          const attestationsTemplate =
+            rulesetRepo.attestationsTemplate(moduleRoot);
           const version = RulesetRepository.getVersionFromTag(tag);
           sourceTemplate.substitute({
             TAG: tag,
           });
+          if (attestationsTemplate) {
+            attestationsTemplate.substitute({
+              TAG: tag,
+            });
+          }
 
           const { moduleName } = await this.createEntryService.createEntryFiles(
             rulesetRepo.metadataTemplate(moduleRoot),
@@ -86,7 +93,8 @@ export class ReleaseEventHandler {
             rulesetRepo.presubmitPath(moduleRoot),
             rulesetRepo.patchesPath(moduleRoot),
             bcr.diskPath,
-            version
+            version,
+            attestationsTemplate
           );
           moduleNames.push(moduleName);
         }

--- a/src/domain/BUILD.bazel
+++ b/src/domain/BUILD.bazel
@@ -5,6 +5,7 @@ ts_project(
     name = "domain",
     srcs = [
         "artifact.ts",
+        "attestations-template.ts",
         "configuration.ts",
         "create-entry.ts",
         "error.ts",
@@ -44,6 +45,7 @@ ts_project(
     testonly = True,
     srcs = [
         "artifact.spec.ts",
+        "attestations-template.spec.ts",
         "configuration.spec.ts",
         "create-entry.spec.ts",
         "find-registry-fork.spec.ts",

--- a/src/domain/attestations-template.spec.ts
+++ b/src/domain/attestations-template.spec.ts
@@ -1,0 +1,374 @@
+import 'jest-extended';
+
+import fs from 'node:fs';
+
+import { mocked } from 'jest-mock';
+
+import { Artifact, ArtifactDownloadError } from './artifact';
+import {
+  AttestationDownloadError,
+  AttestationsTemplate,
+  AttestationsTemplateError,
+  UnsubstitutedAttestationVarsError,
+} from './attestations-template';
+import { SubstitutableVar } from './substitution';
+
+jest.mock('node:fs');
+jest.mock('./artifact');
+
+const ATTESTATIONS_TEMPLATE_PATH = 'attestations.json';
+const VALID_ATTESTATIONS_TEMPLATE = `\
+{
+  "types": ["https://slsa.dev/provenance/v1"],
+  "attestations": {
+    "source.json": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/source.json.intoto.jsonl",
+      "integrity": ""
+    },
+    "MODULE.bazel": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/MODULE.bazel.intoto.jsonl",
+      "integrity": ""
+    },
+    "{REPO}-{TAG}.tar.gz.intoto.jsonl": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz.intoto.jsonl",
+      "integrity": ""
+    }
+  }
+}
+`;
+describe('AttestationsTemplate', () => {
+  beforeEach(() => {
+    mocked(fs.existsSync).mockImplementation((path: fs.PathLike) => {
+      return path === ATTESTATIONS_TEMPLATE_PATH;
+    });
+    mocked(fs.readFileSync).mockImplementation(((path: fs.PathLike) => {
+      if (path === ATTESTATIONS_TEMPLATE_PATH) {
+        return VALID_ATTESTATIONS_TEMPLATE;
+      }
+      throw new Error(`Unmocked file ${path}`);
+    }) as any);
+  });
+
+  describe('tryLoad', () => {
+    test('returns null if the file does not exist', () => {
+      expect(
+        AttestationsTemplate.tryLoad(
+          '/some/nonexistent/path/attestations.template.json'
+        )
+      ).toBeNull();
+    });
+
+    test('returns an AttestationsTemplate if the file exists and is valid', () => {
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      expect(template instanceof AttestationsTemplate).toBe(true);
+    });
+
+    test('throws when file contains invalid JSON', () => {
+      mocked(fs.readFileSync).mockReturnValue(`\
+{
+  "types": ["https://slsa.dev/provenance/v1"],
+  "attestations": {
+    "source.json": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/source.json.intoto.jsonl",
+      "integrity": ""
+    },
+  }
+`);
+      expect(() =>
+        AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH)
+      ).toThrowWithMessage(
+        AttestationsTemplateError,
+        'Expected double-quoted property name in JSON at position 220'
+      );
+    });
+
+    test('throws when file missing attestations field', () => {
+      mocked(fs.readFileSync).mockReturnValue(`\
+{
+  "types": ["https://slsa.dev/provenance/v1"]
+}
+`);
+      expect(() =>
+        AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH)
+      ).toThrowWithMessage(
+        AttestationsTemplateError,
+        'missing attestations field'
+      );
+    });
+
+    test('throws when attestations field is not an object', () => {
+      mocked(fs.readFileSync).mockReturnValue(`\
+{
+  "types": ["https://slsa.dev/provenance/v1"],
+  "attestations": [
+    {"source.json": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/source.json.intoto.jsonl",
+      "integrity": ""
+    }}
+  ]
+}
+`);
+      expect(() =>
+        AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH)
+      ).toThrowWithMessage(
+        AttestationsTemplateError,
+        'invalid attestations field'
+      );
+    });
+
+    test('throws when an attestation is not an object', () => {
+      mocked(fs.readFileSync).mockReturnValue(`\
+{
+  "types": ["https://slsa.dev/provenance/v1"],
+  "attestations": {
+    "source.json": [{
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/source.json.intoto.jsonl",
+      "integrity": ""
+    }]
+  }
+}
+`);
+      expect(() =>
+        AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH)
+      ).toThrowWithMessage(
+        AttestationsTemplateError,
+        'invalid attestation with key source.json'
+      );
+    });
+
+    test('throws when an attestation is missing the url', () => {
+      mocked(fs.readFileSync).mockReturnValue(`\
+{
+  "types": ["https://slsa.dev/provenance/v1"],
+  "attestations": {
+    "source.json": {
+      "integrity": ""
+    }
+  }
+}
+`);
+      expect(() =>
+        AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH)
+      ).toThrowWithMessage(
+        AttestationsTemplateError,
+        'attestation with key source.json is missing url'
+      );
+    });
+
+    test('throws when an attestation url is not a string', () => {
+      mocked(fs.readFileSync).mockReturnValue(`\
+{
+  "types": ["https://slsa.dev/provenance/v1"],
+  "attestations": {
+    "source.json": {
+      "url": 123,
+      "integrity": ""
+    }
+  }
+}
+`);
+      expect(() =>
+        AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH)
+      ).toThrowWithMessage(
+        AttestationsTemplateError,
+        'attestation with key source.json has invalid url'
+      );
+    });
+  });
+
+  describe('substitute', () => {
+    test('substitutes an attestation url', () => {
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      template.substitute({
+        OWNER: 'foo',
+        REPO: 'bar',
+        TAG: 'v1.0.0',
+      });
+      template.save('attestations.json');
+
+      const written = mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(JSON.parse(written).attestations['source.json'].url).toEqual(
+        'https://github.com/foo/bar/releases/download/v1.0.0/source.json.intoto.jsonl'
+      );
+    });
+
+    test('substitutes an attestation key', () => {
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      template.substitute({
+        OWNER: 'foo',
+        REPO: 'bar',
+        TAG: 'v1.0.0',
+      });
+      template.save('attestations.json');
+
+      const written = mocked(fs.writeFileSync).mock.calls[0][1] as string;
+      expect(
+        'bar-v1.0.0.tar.gz.intoto.jsonl' in JSON.parse(written).attestations
+      ).toBe(true);
+    });
+  });
+
+  describe('validateFullySubstituted', () => {
+    test('succeeds when fully substituted', () => {
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      template.substitute({
+        OWNER: 'foo',
+        REPO: 'bar',
+        TAG: 'v1.0.0',
+      });
+      expect(() => template.validateFullySubstituted()).not.toThrow();
+    });
+
+    test('fails when not fully substituted', () => {
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      template.substitute({
+        OWNER: 'foo',
+        // REPO: "bar",
+        TAG: 'v1.0.0',
+      });
+
+      let thrownError: any;
+      try {
+        template.validateFullySubstituted();
+        expect.fail('Expected to throw');
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError instanceof UnsubstitutedAttestationVarsError);
+      const unsubbedVars = (thrownError as UnsubstitutedAttestationVarsError)
+        .unsubstituted;
+      expect(unsubbedVars.size).toEqual(1);
+      expect(unsubbedVars.has(SubstitutableVar.REPO)).toBe(true);
+    });
+  });
+
+  describe('computeIntegrityHashes', () => {
+    test('downloads each attestation', async () => {
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      template.substitute({
+        OWNER: 'foo',
+        REPO: 'bar',
+        TAG: 'v1.0.0',
+      });
+      await template.computeIntegrityHashes();
+
+      const artifacts = mocked(Artifact).mock.instances;
+      expect(artifacts.length).toEqual(3);
+
+      const a1 = artifacts.find(
+        (_, i) =>
+          mocked(Artifact).mock.calls[i][0] ===
+          'https://github.com/foo/bar/releases/download/v1.0.0/source.json.intoto.jsonl'
+      )!;
+      const a2 = artifacts.find(
+        (_, i) =>
+          mocked(Artifact).mock.calls[i][0] ===
+          'https://github.com/foo/bar/releases/download/v1.0.0/MODULE.bazel.intoto.jsonl'
+      )!;
+      const a3 = artifacts.find(
+        (_, i) =>
+          mocked(Artifact).mock.calls[i][0] ===
+          'https://github.com/foo/bar/releases/download/v1.0.0/bar-v1.0.0.tar.gz.intoto.jsonl'
+      )!;
+
+      expect([a1, a2, a3].every((a) => a !== undefined)).toBe(true);
+
+      expect(a1.download).toHaveBeenCalled();
+      expect(a2.download).toHaveBeenCalled();
+      expect(a3.download).toHaveBeenCalled();
+    });
+
+    test('fills out the correct integrity hashes', async () => {
+      jest
+        .spyOn(Artifact.prototype, 'computeIntegrityHash')
+        .mockImplementation(function () {
+          const index = mocked(Artifact).mock.instances.indexOf(this);
+          const url = mocked(Artifact).mock.calls[index][0];
+
+          if (
+            url ===
+            'https://github.com/foo/bar/releases/download/v1.0.0/source.json.intoto.jsonl'
+          ) {
+            return 'sha256-source';
+          } else if (
+            url ===
+            'https://github.com/foo/bar/releases/download/v1.0.0/MODULE.bazel.intoto.jsonl'
+          ) {
+            return 'sha256-module';
+          } else if (
+            url ===
+            'https://github.com/foo/bar/releases/download/v1.0.0/bar-v1.0.0.tar.gz.intoto.jsonl'
+          ) {
+            return 'sha256-archive';
+          }
+
+          throw new Error('Unexpected archive');
+        });
+
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      template.substitute({
+        OWNER: 'foo',
+        REPO: 'bar',
+        TAG: 'v1.0.0',
+      });
+      await template.computeIntegrityHashes();
+
+      const artifacts = mocked(Artifact).mock.instances;
+      expect(artifacts.length).toEqual(3);
+
+      template.save('attestations.json');
+      const written = JSON.parse(
+        mocked(fs.writeFileSync).mock.calls[0][1] as string
+      );
+
+      expect(written.attestations['source.json'].integrity).toEqual(
+        'sha256-source'
+      );
+      expect(written.attestations['MODULE.bazel'].integrity).toEqual(
+        'sha256-module'
+      );
+      expect(
+        written.attestations['bar-v1.0.0.tar.gz.intoto.jsonl'].integrity
+      ).toEqual('sha256-archive');
+    });
+
+    test('throws when an attestation fails to download', async () => {
+      jest
+        .spyOn(Artifact.prototype, 'download')
+        .mockRejectedValue(
+          new ArtifactDownloadError('https://foo/bar/artifact.baz', 404)
+        );
+
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      template.substitute({
+        OWNER: 'foo',
+        REPO: 'bar',
+        TAG: 'v1.0.0',
+      });
+
+      await expect(template.computeIntegrityHashes()).rejects.toThrow(
+        AttestationDownloadError
+      );
+    });
+  });
+
+  describe('save', () => {
+    test('saves the template to disk', () => {
+      const template = AttestationsTemplate.tryLoad(ATTESTATIONS_TEMPLATE_PATH);
+      template.save('attestations.json');
+
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        'attestations.json',
+        expect.any(String),
+        'utf8'
+      );
+      const written = JSON.parse(
+        mocked(fs.writeFileSync).mock.calls[0][1] as string
+      );
+      expect(written).toEqual(
+        JSON.parse(fs.readFileSync(ATTESTATIONS_TEMPLATE_PATH, 'utf8'))
+      );
+    });
+  });
+});

--- a/src/domain/attestations-template.ts
+++ b/src/domain/attestations-template.ts
@@ -1,0 +1,188 @@
+import fs from 'node:fs';
+
+import { Artifact, ArtifactDownloadError } from './artifact.js';
+import { UserFacingError } from './error.js';
+import {
+  getUnsubstitutedVars,
+  SubstitutableVar,
+  substituteVars,
+} from './substitution.js';
+
+export class AttestationsTemplateError extends Error {
+  constructor(
+    public readonly path: string,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export class UnsubstitutedAttestationVarsError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly unsubstituted: Set<SubstitutableVar>
+  ) {
+    super();
+  }
+}
+
+export class AttestationDownloadError extends UserFacingError {
+  constructor(
+    public readonly url: string,
+    public readonly statusCode: number
+  ) {
+    let msg = `Failed to download attestation from ${url}. Received status ${statusCode}.`;
+
+    if (statusCode === 404) {
+      msg +=
+        "\n\nDouble check that the `url` in your ruleset's .bcr/attestations.template.json is correct.";
+    }
+    super(msg);
+  }
+}
+
+export class AttestationsTemplate {
+  // Preserve the original parse JSON structure. It's up to the
+  // user to provider a correct template. We only parse and validate
+  // the fields that Publish to BCR cares about.
+  private json: Record<string, unknown>;
+
+  public static tryLoad(filePath: string): AttestationsTemplate | null {
+    if (fs.existsSync(filePath)) {
+      return new AttestationsTemplate(filePath);
+    }
+    return null;
+  }
+
+  private constructor(private readonly filePath: string) {
+    this.parseAndValidate(this.filePath);
+  }
+
+  // Perform a minimal validation of the attestation fields that Publish
+  // to BCR needs to work with. It's up to the user to provide a correctly
+  // structure attestations document.
+  private parseAndValidate(filePath: string) {
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      this.json = JSON.parse(content);
+    } catch (e) {
+      throw new AttestationsTemplateError(this.filePath, e.message);
+    }
+
+    if (!this.json.attestations) {
+      throw new AttestationsTemplateError(
+        this.filePath,
+        'missing attestations field'
+      );
+    }
+
+    if (!isObject(this.json.attestations)) {
+      throw new AttestationsTemplateError(
+        this.filePath,
+        'invalid attestations field'
+      );
+    }
+
+    for (const key of Object.keys(this.json.attestations)) {
+      const attestation = (this.json.attestations as any)[key];
+      if (!isObject(attestation)) {
+        throw new AttestationsTemplateError(
+          this.filePath,
+          `invalid attestation with key ${key}`
+        );
+      }
+
+      if (!attestation.url) {
+        throw new AttestationsTemplateError(
+          this.filePath,
+          `attestation with key ${key} is missing url`
+        );
+      }
+
+      if (typeof attestation.url !== 'string') {
+        throw new AttestationsTemplateError(
+          this.filePath,
+          `attestation with key ${key} has invalid url`
+        );
+      }
+    }
+  }
+
+  public substitute(
+    vars: Partial<Record<SubstitutableVar, string>>
+  ): AttestationsTemplate {
+    // Substitute the url field of all attestations
+    for (const key of Object.keys(this.json.attestations)) {
+      const attestation = (this.json.attestations as any)[key];
+      attestation.url = substituteVars(attestation.url, vars);
+    }
+
+    // Substitute the attestation keys
+    for (const key of Object.keys(this.json.attestations)) {
+      const subbedKey = substituteVars(key, vars);
+      if (subbedKey !== key) {
+        (this.json.attestations as any)[subbedKey] = (
+          this.json.attestations as any
+        )[key];
+        delete (this.json.attestations as any)[key];
+      }
+    }
+
+    return this;
+  }
+
+  public validateFullySubstituted(): void {
+    const unsubstituted = new Set<SubstitutableVar>();
+
+    for (const key of Object.keys(this.json.attestations)) {
+      getUnsubstitutedVars(key).forEach((v) => unsubstituted.add(v));
+      const attestation = (this.json.attestations as any)[key];
+      getUnsubstitutedVars(attestation.url as string).forEach((v) =>
+        unsubstituted.add(v)
+      );
+    }
+
+    if (unsubstituted.size > 0) {
+      throw new UnsubstitutedAttestationVarsError(this.filePath, unsubstituted);
+    }
+  }
+
+  public async computeIntegrityHashes(): Promise<void> {
+    const urls: string[] = [];
+    const keys = Object.keys(this.json.attestations);
+
+    for (const key of keys) {
+      const attestation = (this.json.attestations as any)[key];
+      urls.push(attestation.url);
+    }
+
+    const artifacts = urls.map((url) => new Artifact(url));
+
+    try {
+      await Promise.all(artifacts.map((artifact) => artifact.download()));
+    } catch (e) {
+      if (e instanceof ArtifactDownloadError) {
+        throw new AttestationDownloadError(e.url, e.statusCode);
+      }
+      throw e;
+    }
+
+    for (let i = 0; i < keys.length; i++) {
+      const attestation = (this.json.attestations as any)[keys[i]];
+      attestation.integrity = artifacts[i].computeIntegrityHash();
+    }
+  }
+
+  public save(destPath: string) {
+    fs.writeFileSync(
+      destPath,
+      `${JSON.stringify(this.json, undefined, 4)}\n`,
+      'utf8'
+    );
+  }
+}
+
+function isObject(x: any): boolean {
+  // https://stackoverflow.com/a/8511350
+  return typeof x === 'object' && !Array.isArray(x) && x !== null;
+}

--- a/src/domain/publish-entry.ts
+++ b/src/domain/publish-entry.ts
@@ -41,8 +41,7 @@ export class PublishEntryService {
       commitAuthor.name,
       commitAuthor.email
     );
-    console.error(bcrRepo.diskPath);
-    console.error(branchName);
+
     await this.gitClient.checkoutNewBranchFromHead(
       bcrRepo.diskPath,
       branchName

--- a/src/domain/substitution.ts
+++ b/src/domain/substitution.ts
@@ -1,5 +1,3 @@
-// export type SubstitutableVar = 'OWNER' | 'REPO' | 'TAG' | 'VERSION';
-
 export enum SubstitutableVar {
   OWNER = 'OWNER',
   REPO = 'REPO',

--- a/src/test/mock-template-files.ts
+++ b/src/test/mock-template-files.ts
@@ -158,3 +158,32 @@ ${
 }
 `;
 }
+
+export function fakeAttestationsFile(
+  options: {
+    content?: string;
+  } = {}
+): string {
+  if (options.content) {
+    return options.content;
+  }
+  return `\
+{
+  "types": ["https://slsa.dev/provenance/v1"],
+  "attestations": {
+    "source.json": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/source.json.intoto.jsonl",
+      "integrity": ""
+    },
+    "MODULE.bazel": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/MODULE.bazel.intoto.jsonl",
+      "integrity": ""
+    },
+    "{REPO}-{TAG}.tar.gz.intoto.jsonl": {
+      "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz.intoto.jsonl",
+      "integrity": ""
+    }
+  }
+}
+`;
+}


### PR DESCRIPTION
Generate `attestations.json` from an optional template. Substitute variables and calculate integrity hashes.

Prefactors:
* https://github.com/bazel-contrib/publish-to-bcr/pull/240
* https://github.com/bazel-contrib/publish-to-bcr/pull/241