### PR TITLE
refactor: model release artifacts

### DIFF
--- a/src/domain/BUILD.bazel
+++ b/src/domain/BUILD.bazel
@@ -4,6 +4,7 @@ load("//bazel/ts:defs.bzl", "ts_project")
 ts_project(
     name = "domain",
     srcs = [
+        "artifact.ts",
         "configuration.ts",
         "create-entry.ts",
         "error.ts",
@@ -41,6 +42,7 @@ ts_project(
     name = "domain_tests",
     testonly = True,
     srcs = [
+        "artifact.spec.ts",
         "configuration.spec.ts",
         "create-entry.spec.ts",
         "find-registry-fork.spec.ts",

--- a/src/domain/artifact.spec.ts
+++ b/src/domain/artifact.spec.ts
@@ -1,0 +1,196 @@
+import { randomUUID } from 'node:crypto';
+import fs, { WriteStream } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import axios from 'axios';
+import axiosRetry from 'axios-retry';
+import { mocked } from 'jest-mock';
+
+import { expectThrownError } from '../test/util';
+import { Artifact, ArtifactDownloadError } from './artifact';
+import { computeIntegrityHash } from './integrity-hash';
+
+jest.mock('node:fs');
+jest.mock('node:os');
+jest.mock('axios');
+jest.mock('axios-retry');
+jest.mock('./integrity-hash');
+
+const ARTIFACT_URL = 'https://foo.bar/artifact.baz';
+const TEMP_DIR = '/tmp';
+const TEMP_FOLDER = 'artifact-1234';
+
+beforeEach(() => {
+  mocked(axios.get).mockReturnValue(
+    Promise.resolve({
+      data: {
+        pipe: jest.fn(),
+      },
+      status: 200,
+    })
+  );
+
+  mocked(fs.createWriteStream).mockReturnValue({
+    on: jest.fn((event: string, func: (...args: any[]) => unknown) => {
+      if (event === 'finish') {
+        func();
+      }
+    }),
+  } as any);
+
+  mocked(os.tmpdir).mockReturnValue(TEMP_DIR);
+  mocked(fs.mkdtempSync).mockReturnValue(path.join(TEMP_DIR, TEMP_FOLDER));
+  mocked(computeIntegrityHash).mockReturnValue(`sha256-${randomUUID()}`);
+});
+
+describe('Artifact', () => {
+  describe('download', () => {
+    test('downloads the artifact', async () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+      await artifact.download();
+
+      expect(axios.get).toHaveBeenCalledWith(ARTIFACT_URL, {
+        responseType: 'stream',
+      });
+    });
+
+    test('retries the request if it fails', async () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+
+      // Restore the original behavior of exponentialDelay.
+      mocked(axiosRetry.exponentialDelay).mockImplementation(
+        jest.requireActual('axios-retry').exponentialDelay
+      );
+
+      await artifact.download();
+
+      expect(axiosRetry).toHaveBeenCalledWith(axios, {
+        retries: 3,
+
+        retryCondition: expect.matchesPredicate(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+          (retryConditionFn: Function) => {
+            // Make sure HTTP 404 errors are retried.
+            const notFoundError = { response: { status: 404 } };
+            return retryConditionFn.call(this, notFoundError);
+          }
+        ),
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+        retryDelay: expect.matchesPredicate((retryDelayFn: Function) => {
+          // Make sure the retry delays follow exponential backoff
+          // and the final retry happens after at least 1 minute total
+          // (in this case, at least 70 seconds).
+          // Axios randomly adds an extra 0-20% of jitter to each delay.
+          // Test upper bounds as well to ensure the workflow completes reasonably quickly
+          // (in this case, no more than 84 seconds total).
+          const firstRetryDelay = retryDelayFn.call(this, 0);
+          const secondRetryDelay = retryDelayFn.call(this, 1);
+          const thirdRetryDelay = retryDelayFn.call(this, 2);
+          return (
+            10000 <= firstRetryDelay &&
+            firstRetryDelay <= 12000 &&
+            20000 <= secondRetryDelay &&
+            secondRetryDelay <= 24000 &&
+            40000 <= thirdRetryDelay &&
+            thirdRetryDelay <= 48000
+          );
+        }),
+        shouldResetTimeout: true,
+      });
+    });
+
+    test('saves the artifact to disk', async () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+
+      await artifact.download();
+
+      const expectedPath = path.join(TEMP_DIR, TEMP_FOLDER, 'artifact.baz');
+      expect(fs.createWriteStream).toHaveBeenCalledWith(expectedPath, {
+        flags: 'w',
+      });
+
+      const mockedAxiosResponse = await (mocked(axios.get).mock.results[0]
+        .value as Promise<{ data: { pipe: Function } }>); // eslint-disable-line @typescript-eslint/no-unsafe-function-type
+      const mockedWriteStream = mocked(fs.createWriteStream).mock.results[0]
+        .value as WriteStream;
+
+      expect(mockedAxiosResponse.data.pipe).toHaveBeenCalledWith(
+        mockedWriteStream
+      );
+    });
+
+    test('sets the diskPath', async () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+
+      await artifact.download();
+
+      const expectedPath = path.join(TEMP_DIR, TEMP_FOLDER, 'artifact.baz');
+      expect(artifact.diskPath).toEqual(expectedPath);
+    });
+
+    test('throws on a non 200 status', async () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+
+      mocked(axios.get).mockRejectedValue({
+        response: {
+          status: 401,
+        },
+      });
+
+      const thrownError = await expectThrownError(
+        () => artifact.download(),
+        ArtifactDownloadError
+      );
+
+      expect(thrownError.message.includes(ARTIFACT_URL)).toEqual(true);
+      expect(thrownError.message.includes('401')).toEqual(true);
+    });
+  });
+
+  describe('computeIntegrityHash', () => {
+    test('throws when artifact has not yet been downloaded', () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+
+      expect(() => artifact.computeIntegrityHash()).toThrowWithMessage(
+        Error,
+        `The artifact ${ARTIFACT_URL} must be downloaded before an integrity hash can be calculated`
+      );
+    });
+
+    test('computes the integrity of the file', async () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+      await artifact.download();
+
+      const expected = `sha256-${randomUUID()}`;
+      mocked(computeIntegrityHash).mockReturnValue(expected);
+
+      const actual = await artifact.computeIntegrityHash();
+
+      expect(expected).toEqual(actual);
+      expect(computeIntegrityHash).toHaveBeenCalledWith(artifact.diskPath);
+    });
+  });
+
+  describe('cleanup', () => {
+    test('removed the stored file', async () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+      await artifact.download();
+      const diskPath = artifact.diskPath;
+      artifact.cleanup();
+
+      expect(fs.rmSync).toHaveBeenCalledWith(diskPath, { force: true });
+    });
+
+    test('removes the diskPath', async () => {
+      const artifact = new Artifact(ARTIFACT_URL);
+      await artifact.download();
+      artifact.cleanup();
+
+      expect(() => artifact.diskPath).toThrowWithMessage(
+        Error,
+        `The artifact ${ARTIFACT_URL} has not been downloaded yet`
+      );
+    });
+  });
+});

--- a/src/domain/artifact.ts
+++ b/src/domain/artifact.ts
@@ -1,0 +1,147 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parse as parseUrl } from 'node:url';
+
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import axiosRetry from 'axios-retry';
+
+import { computeIntegrityHash } from './integrity-hash.js';
+
+export class ArtifactDownloadError extends Error {
+  constructor(
+    public readonly url: string,
+    public readonly statusCode: number
+  ) {
+    super(
+      `Failed to download artifact from ${url}. Received status ${statusCode}`
+    );
+  }
+}
+
+/**
+ * An artifact that can be downloaded and have its integrity hash computed.
+ */
+export class Artifact {
+  private _diskPath: string | null = null;
+  public constructor(public readonly url: string) {}
+
+  public async download(): Promise<void> {
+    let url = this.url;
+    if (this._diskPath !== null) {
+      throw new Error(
+        `Artifact ${url} already downloaded to ${this._diskPath}`
+      );
+    }
+
+    const parsed = parseUrl(url);
+
+    if (process.env.INTEGRATION_TESTING) {
+      // Point downloads to the standin github server
+      // during integration testing.
+      const [host, port] =
+        process.env.GITHUB_API_ENDPOINT.split('://')[1].split(':');
+
+      parsed.host = host;
+      parsed.port = port;
+
+      url = `http://${host}:${port}${parsed.path}`;
+    }
+
+    const filename = path.basename(parsed.pathname);
+
+    const dest = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-')),
+      filename
+    );
+
+    // Support downloading from another location on disk.
+    // Useful for swapping in a local path for e2e tests.
+    if (url.startsWith('file://')) {
+      fs.copyFileSync(url.substring('file://'.length), dest);
+      this._diskPath = dest;
+      return;
+    }
+
+    const writer = fs.createWriteStream(dest, { flags: 'w' });
+
+    // Retry the request in case the artifact is still being uploaded.
+    // Exponential backoff with 3 retries and a delay factor of 10 seconds
+    // gives you at least 70 seconds to upload a release archive.
+    axiosRetry(axios, {
+      retries: 3,
+      retryDelay: exponentialDelay,
+      shouldResetTimeout: true,
+      retryCondition: defaultRetryPlus404,
+    });
+
+    let response: AxiosResponse;
+
+    try {
+      response = await axios.get(url, {
+        responseType: 'stream',
+      });
+    } catch (e: any) {
+      // https://axios-http.com/docs/handling_errors
+      if (e.response) {
+        throw new ArtifactDownloadError(url, e.response.status);
+      } else if (e.request) {
+        throw new Error(`GET ${url} failed; no response received`);
+      } else {
+        throw new Error(`Failed to GET ${url} failed: ${e.message}`);
+      }
+    }
+
+    response.data.pipe(writer);
+
+    await new Promise((resolve, reject) => {
+      writer.on('finish', () => {
+        this._diskPath = dest;
+        resolve(null);
+      });
+      writer.on('error', reject);
+    });
+  }
+
+  public get diskPath(): string {
+    if (this._diskPath === null) {
+      throw new Error(`The artifact ${this.url} has not been downloaded yet`);
+    }
+
+    return this._diskPath;
+  }
+
+  public computeIntegrityHash(): string {
+    if (this._diskPath === null) {
+      throw new Error(
+        `The artifact ${this.url} must be downloaded before an integrity hash can be calculated`
+      );
+    }
+    return computeIntegrityHash(this._diskPath);
+  }
+
+  public cleanup(): void {
+    fs.rmSync(this._diskPath, { force: true });
+    this._diskPath = null;
+  }
+}
+
+function exponentialDelay(
+  retryCount: number,
+  error: AxiosError | undefined
+): number {
+  // Default delay factor is 10 seconds, but can be overridden for testing.
+  const delayFactor = Number(process.env.BACKOFF_DELAY_FACTOR) || 10_000;
+  return axiosRetry.exponentialDelay(retryCount, error, delayFactor);
+}
+
+function defaultRetryPlus404(error: AxiosError): boolean {
+  // Publish-to-BCR needs to support retrying when GitHub returns 404
+  // in order to support automated release workflows that upload artifacts
+  // within a minute or so of publishing a release.
+  // Apart from this case, use the default retry condition.
+  return (
+    error.response.status === 404 ||
+    axiosRetry.isNetworkOrIdempotentRequestError(error)
+  );
+}

--- a/src/domain/create-entry.spec.ts
+++ b/src/domain/create-entry.spec.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto';
 import fs, { PathLike } from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 
 import { createTwoFilesPatch } from 'diff';
@@ -14,6 +13,7 @@ import {
   fakeSourceFile,
 } from '../test/mock-template-files';
 import { expectThrownError } from '../test/util';
+import { Artifact } from './artifact';
 import {
   CreateEntryService,
   PatchModuleError,
@@ -34,6 +34,7 @@ jest.mock('../infrastructure/git');
 jest.mock('../infrastructure/github');
 jest.mock('./integrity-hash');
 jest.mock('./release-archive');
+jest.mock('./artifact');
 jest.mock('node:fs');
 jest.mock('exponential-backoff');
 
@@ -81,7 +82,10 @@ beforeEach(() => {
     extractModuleFile: jest.fn(async () => {
       return new ModuleFile(EXTRACTED_MODULE_PATH);
     }),
-    diskPath: path.join(os.tmpdir(), 'archive.tar.gz'),
+    artifact: {
+      computeIntegrityHash: jest.fn().mockReturnValue(`sha256-${randomUUID()}`),
+      cleanup: jest.fn(),
+    } as Partial<Artifact> as Artifact,
     cleanup: jest.fn(),
   } as Partial<ReleaseArchive> as ReleaseArchive;
 
@@ -631,7 +635,9 @@ describe('createEntryFiles', () => {
       const bcrRepo = CANONICAL_BCR;
 
       const hash = `sha256-${randomUUID()}`;
-      mocked(computeIntegrityHash).mockReturnValue(hash);
+      mocked(mockReleaseArchive.artifact.computeIntegrityHash).mockReturnValue(
+        hash
+      );
 
       await rulesetRepo.shallowCloneAndCheckout(tag);
       await bcrRepo.shallowCloneAndCheckout('main');
@@ -659,7 +665,9 @@ describe('createEntryFiles', () => {
       const bcrRepo = CANONICAL_BCR;
 
       const hash = `sha256-${randomUUID()}`;
-      mocked(computeIntegrityHash).mockReturnValue(hash);
+      mocked(mockReleaseArchive.artifact.computeIntegrityHash).mockReturnValue(
+        hash
+      );
 
       await rulesetRepo.shallowCloneAndCheckout(tag);
       await bcrRepo.shallowCloneAndCheckout('main');
@@ -723,7 +731,9 @@ describe('createEntryFiles', () => {
       const bcrRepo = CANONICAL_BCR;
 
       const hash = `sha256-${randomUUID()}`;
-      mocked(computeIntegrityHash).mockReturnValue(hash);
+      mocked(mockReleaseArchive.artifact.computeIntegrityHash).mockReturnValue(
+        hash
+      );
 
       await rulesetRepo.shallowCloneAndCheckout(tag);
       await bcrRepo.shallowCloneAndCheckout('main');
@@ -760,9 +770,9 @@ describe('createEntryFiles', () => {
       const hash1 = `sha256-${randomUUID()}`;
       const hash2 = `sha256-${randomUUID()}`;
 
-      mocked(computeIntegrityHash).mockReturnValueOnce(
-        `sha256-${randomUUID()}`
-      ); // release archive
+      mocked(
+        mockReleaseArchive.artifact.computeIntegrityHash
+      ).mockReturnValueOnce(`sha256-${randomUUID()}`); // release archive
       mocked(computeIntegrityHash).mockReturnValueOnce(hash1);
       mocked(computeIntegrityHash).mockReturnValueOnce(hash2);
 
@@ -793,7 +803,9 @@ describe('createEntryFiles', () => {
       const bcrRepo = CANONICAL_BCR;
 
       const hash = `sha256-${randomUUID()}`;
-      mocked(computeIntegrityHash).mockReturnValue(hash);
+      mocked(mockReleaseArchive.artifact.computeIntegrityHash).mockReturnValue(
+        hash
+      );
 
       await rulesetRepo.shallowCloneAndCheckout(tag);
       await bcrRepo.shallowCloneAndCheckout('main');
@@ -830,7 +842,9 @@ describe('createEntryFiles', () => {
     const bcrRepo = CANONICAL_BCR;
 
     const hash = `sha256-${randomUUID()}`;
-    mocked(computeIntegrityHash).mockReturnValueOnce(`sha256-${randomUUID()}`); // release archive
+    mocked(
+      mockReleaseArchive.artifact.computeIntegrityHash
+    ).mockReturnValueOnce(`sha256-${randomUUID()}`); // release archive
     mocked(computeIntegrityHash).mockReturnValueOnce(hash);
 
     await rulesetRepo.shallowCloneAndCheckout(tag);

--- a/src/domain/create-entry.ts
+++ b/src/domain/create-entry.ts
@@ -49,8 +49,9 @@ export class CreateEntryService {
     );
 
     try {
-      const integrityHash = computeIntegrityHash(releaseArchive.diskPath);
-      sourceTemplate.setIntegrityHash(integrityHash);
+      sourceTemplate.setIntegrityHash(
+        releaseArchive.artifact.computeIntegrityHash()
+      );
 
       const moduleFile = await releaseArchive.extractModuleFile();
 

--- a/src/domain/release-archive.ts
+++ b/src/domain/release-archive.ts
@@ -1,14 +1,11 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
-import { parse as parseUrl } from 'node:url';
 
-import axios, { AxiosError, AxiosResponse } from 'axios';
-import axiosRetry from 'axios-retry';
 import extractZip from 'extract-zip';
 import tar from 'tar';
 
 import { decompress as decompressXz } from '../infrastructure/xzdec/xzdec.js';
+import { Artifact, ArtifactDownloadError } from './artifact.js';
 import { UserFacingError } from './error.js';
 import { ModuleFile } from './module-file.js';
 
@@ -55,34 +52,37 @@ export class ReleaseArchive {
     url: string,
     stripPrefix: string
   ): Promise<ReleaseArchive> {
-    const filename = url.substring(url.lastIndexOf('/') + 1);
-    const downloadedPath = path.join(
-      fs.mkdtempSync(path.join(os.tmpdir(), 'archive-')),
-      filename
-    );
-    await download(url, downloadedPath);
+    const artifact = new Artifact(url);
 
-    return new ReleaseArchive(url, downloadedPath, stripPrefix);
+    try {
+      await artifact.download();
+    } catch (e) {
+      if (e instanceof ArtifactDownloadError) {
+        throw new ArchiveDownloadError(e.url, e.statusCode);
+      }
+      throw e;
+    }
+
+    return new ReleaseArchive(artifact, stripPrefix);
   }
 
   private extractDir: string | undefined;
 
   private constructor(
-    private readonly url: string,
-    private readonly _diskPath: string,
+    public readonly artifact: Artifact,
     private readonly stripPrefix: string
   ) {}
 
   public async extractModuleFile(): Promise<ModuleFile> {
-    this.extractDir = path.dirname(this._diskPath);
+    this.extractDir = path.dirname(this.artifact.diskPath);
 
     if (this.isSupportedTarball()) {
       await this.extractReleaseTarball(this.extractDir);
-    } else if (this._diskPath.endsWith('.zip')) {
+    } else if (this.artifact.diskPath.endsWith('.zip')) {
       await this.extractReleaseZip(this.extractDir);
     } else {
-      const extension = this._diskPath.split('.').slice(1).join('.');
-      throw new UnsupportedArchiveFormat(this.url, extension);
+      const extension = this.artifact.diskPath.split('.').slice(1).join('.');
+      throw new UnsupportedArchiveFormat(this.artifact.url, extension);
     }
 
     const pathInArchive = path.join(this.stripPrefix, 'MODULE.bazel');
@@ -97,21 +97,21 @@ export class ReleaseArchive {
   }
 
   private isSupportedTarball(): boolean {
-    if (this._diskPath.endsWith('.tar')) {
+    if (this.artifact.diskPath.endsWith('.tar')) {
       return true;
     }
-    if (this._diskPath.endsWith('.tar.gz')) {
+    if (this.artifact.diskPath.endsWith('.tar.gz')) {
       return true;
     }
-    if (this._diskPath.endsWith('.tar.xz')) {
+    if (this.artifact.diskPath.endsWith('.tar.xz')) {
       return true;
     }
     return false;
   }
 
   private async extractReleaseTarball(extractDir: string): Promise<void> {
-    if (this._diskPath.endsWith('.tar.xz')) {
-      const reader = fs.createReadStream(this._diskPath);
+    if (this.artifact.diskPath.endsWith('.tar.xz')) {
+      const reader = fs.createReadStream(this.artifact.diskPath);
       const writer = tar.x({
         cwd: extractDir,
       });
@@ -126,104 +126,22 @@ export class ReleaseArchive {
 
     await tar.x({
       cwd: extractDir,
-      file: this._diskPath,
+      file: this.artifact.diskPath,
     });
   }
 
   private async extractReleaseZip(extractDir: string): Promise<void> {
-    await extractZip(this._diskPath, { dir: extractDir });
-  }
-
-  public get diskPath(): string {
-    return this._diskPath;
+    await extractZip(this.artifact.diskPath, { dir: extractDir });
   }
 
   /**
    * Delete the release archive and extracted contents
    */
   public cleanup(): void {
-    fs.rmSync(this._diskPath, { force: true });
+    this.artifact.cleanup();
 
     if (this.extractDir) {
       fs.rmSync(this.extractDir, { force: true, recursive: true });
     }
   }
-}
-
-function exponentialDelay(
-  retryCount: number,
-  error: AxiosError | undefined
-): number {
-  // Default delay factor is 10 seconds, but can be overridden for testing.
-  const delayFactor = Number(process.env.BACKOFF_DELAY_FACTOR) || 10_000;
-  return axiosRetry.exponentialDelay(retryCount, error, delayFactor);
-}
-
-function defaultRetryPlus404(error: AxiosError): boolean {
-  // Publish-to-BCR needs to support retrying when GitHub returns 404
-  // in order to support automated release workflows that upload artifacts
-  // within a minute or so of publishing a release.
-  // Apart from this case, use the default retry condition.
-  return (
-    error.response.status === 404 ||
-    axiosRetry.isNetworkOrIdempotentRequestError(error)
-  );
-}
-
-async function download(url: string, dest: string): Promise<void> {
-  if (process.env.INTEGRATION_TESTING) {
-    // Point downloads to the standin github server
-    // during integration testing.
-    const [host, port] =
-      process.env.GITHUB_API_ENDPOINT.split('://')[1].split(':');
-
-    const parsed = parseUrl(url);
-    parsed.host = host;
-    parsed.port = port;
-
-    url = `http://${host}:${port}${parsed.path}`;
-  }
-
-  // Support downloading from another location on disk.
-  // Useful for swapping in a local path for e2e tests.
-  if (url.startsWith('file://')) {
-    fs.copyFileSync(url.substring('file://'.length), dest);
-    return;
-  }
-
-  const writer = fs.createWriteStream(dest, { flags: 'w' });
-
-  // Retry the request in case the artifact is still being uploaded.
-  // Exponential backoff with 3 retries and a delay factor of 10 seconds
-  // gives you at least 70 seconds to upload a release archive.
-  axiosRetry(axios, {
-    retries: 3,
-    retryDelay: exponentialDelay,
-    shouldResetTimeout: true,
-    retryCondition: defaultRetryPlus404,
-  });
-
-  let response: AxiosResponse;
-
-  try {
-    response = await axios.get(url, {
-      responseType: 'stream',
-    });
-  } catch (e: any) {
-    // https://axios-http.com/docs/handling_errors
-    if (e.response) {
-      throw new ArchiveDownloadError(url, e.response.status);
-    } else if (e.request) {
-      throw new Error(`GET ${url} failed; no response received`);
-    } else {
-      throw new Error(`Failed to GET ${url} failed: ${e.message}`);
-    }
-  }
-
-  response.data.pipe(writer);
-
-  await new Promise((resolve, reject) => {
-    writer.on('finish', resolve);
-    writer.on('error', reject);
-  });
 }


### PR DESCRIPTION
An artifact is some remote file that gets downloaded and has its integrity hash computed.

Prefactor for https://github.com/bazel-contrib/publish-to-bcr/pull/239 where attestation artifacts need to be downloaded.