### PR TITLE
refactor: move substitution out of source template

### DIFF
--- a/src/application/cli/create-entry-command.ts
+++ b/src/application/cli/create-entry-command.ts
@@ -19,11 +19,11 @@ import {
 import { Repository } from '../../domain/repository.js';
 import {
   SourceTemplate,
-  SubstitutableVar,
   UnsubstitutedVarsError,
 } from '../../domain/source-template.js';
 import { SourceTemplateError } from '../../domain/source-template.js';
 import { CreateEntryArgs } from './yargs.js';
+import { SubstitutableVar } from '../../domain/substitution.js';
 
 export interface CreateEntryCommandOutput {
   moduleName: string;
@@ -113,12 +113,15 @@ export class CreateEntryCommand {
       console.error(
         `Source template ${e.path} has unsubstituted variables ${Array.from(e.unsubstituted).join(',')}`
       );
-      if (e.unsubstituted.has('OWNER') || e.unsubstituted.has('REPO')) {
+      if (
+        e.unsubstituted.has(SubstitutableVar.OWNER) ||
+        e.unsubstituted.has(SubstitutableVar.REPO)
+      ) {
         console.error(
           'Did you forget to pass --github-repository to substitute the OWNER and REPO variables?'
         );
       }
-      if (e.unsubstituted.has('TAG')) {
+      if (e.unsubstituted.has(SubstitutableVar.TAG)) {
         console.error(
           'Did you forget to pass --tag to substitute the TAG variable?'
         );

--- a/src/domain/BUILD.bazel
+++ b/src/domain/BUILD.bazel
@@ -17,6 +17,7 @@ ts_project(
         "repository.ts",
         "ruleset-repository.ts",
         "source-template.ts",
+        "substitution.ts",
         "user.ts",
         "version.ts",
     ],
@@ -54,6 +55,7 @@ ts_project(
         "repository.spec.ts",
         "ruleset-repository.spec.ts",
         "source-template.spec.ts",
+        "substitution.spec.ts",
         "version.spec.ts",
     ],
     deps = [

--- a/src/domain/substitution.spec.ts
+++ b/src/domain/substitution.spec.ts
@@ -1,0 +1,69 @@
+import {
+  getUnsubstitutedVars,
+  SubstitutableVar,
+  substituteVars,
+} from './substitution';
+
+describe('substituteVars', () => {
+  test('substitutes a variable', () => {
+    const str = 'The repo is {REPO}';
+    const sub = substituteVars(str, { REPO: 'foo' });
+
+    expect(sub).toEqual('The repo is foo');
+  });
+
+  test('substitutes duplicates of a variable', () => {
+    const str = 'The repo is {REPO}. Yes, it is {REPO}.';
+    const sub = substituteVars(str, { REPO: 'foo' });
+
+    expect(sub).toEqual('The repo is foo. Yes, it is foo.');
+  });
+
+  test('substitutes multiple variables', () => {
+    const str = 'The repo is {REPO}. The owner is {OWNER}.';
+    const sub = substituteVars(str, { REPO: 'foo', OWNER: 'bar' });
+
+    expect(sub).toEqual('The repo is foo. The owner is bar.');
+  });
+
+  test('does not substitute an unknown variable', () => {
+    const str = 'The meaning of life is {UNKNOWN}.';
+    const sub = substituteVars(str, { REPO: 'foo' });
+
+    expect(sub).toEqual('The meaning of life is {UNKNOWN}.');
+  });
+});
+
+describe('getUnsubstitutedVars', () => {
+  test('gets an unsubstituted var', () => {
+    const str = 'The repo is {REPO}';
+    const vars = getUnsubstitutedVars(str);
+
+    expect(vars.size).toEqual(1);
+    expect(vars.has(SubstitutableVar.REPO)).toBe(true);
+  });
+
+  test('gets duplicated unsubstituted var', () => {
+    const str = 'The repo is {REPO}. Yes, it is {REPO}.';
+    const vars = getUnsubstitutedVars(str);
+
+    expect(vars.size).toEqual(1);
+    expect(vars.has(SubstitutableVar.REPO)).toBe(true);
+  });
+
+  test('gets an multiple ubsubstituted vars', () => {
+    const str = 'The repo is {REPO}. The owner is {OWNER}.';
+    const vars = getUnsubstitutedVars(str);
+
+    expect(vars.size).toEqual(2);
+    expect(vars.has(SubstitutableVar.REPO)).toBe(true);
+    expect(vars.has(SubstitutableVar.OWNER)).toBe(true);
+  });
+
+  test('does not get unknown vars', () => {
+    const str = 'The meaning of life is {UNKNOWN}.';
+    const vars = getUnsubstitutedVars(str);
+
+    expect(vars.size).toEqual(0);
+  });
+});

--- a/src/domain/substitution.ts
+++ b/src/domain/substitution.ts
@@ -1,0 +1,32 @@
+// export type SubstitutableVar = 'OWNER' | 'REPO' | 'TAG' | 'VERSION';
+
+export enum SubstitutableVar {
+  OWNER = 'OWNER',
+  REPO = 'REPO',
+  TAG = 'TAG',
+  VERSION = 'VERSION',
+}
+
+export const ALL_SUBSTITUTABLE_VARS = Object.values(SubstitutableVar);
+
+export function substituteVars(
+  str: string,
+  vars: Partial<Record<SubstitutableVar, string>>
+): string {
+  for (const key of Object.keys(vars)) {
+    str = str.replaceAll(`{${key}}`, vars[key as SubstitutableVar]);
+  }
+  return str;
+}
+
+export function getUnsubstitutedVars(str: string): Set<SubstitutableVar> {
+  const unsubstituted = new Set<SubstitutableVar>();
+
+  for (const templateVar of ALL_SUBSTITUTABLE_VARS) {
+    if (str.includes(`{${templateVar}}`)) {
+      unsubstituted.add(templateVar);
+    }
+  }
+
+  return unsubstituted;
+}


### PR DESCRIPTION
Move some template substitution logic outside of the source template class so it can be reused for the attestations template.

Prefactor for https://github.com/bazel-contrib/publish-to-bcr/pull/239.