### PR TITLE
test: add an integration test for xz decompression

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,7 @@ bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_multitool", version = "0.15.0")
 bazel_dep(name = "rules_nodejs", version = "6.3.3")
 bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "rules_xz", version = "1.0.1")
 bazel_dep(name = "toolchains_llvm", version = "1.2.0")
 bazel_dep(name = "xz", version = "5.4.5.bcr.5")
 

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": ["babel-plugin-transform-import-meta"]
 }

--- a/bazel/jest/defs.bzl
+++ b/bazel/jest/defs.bzl
@@ -31,6 +31,7 @@ def jest_test(name, **kwargs):
         data = data + [
             "babel.config.json",
             "//:node_modules/@babel/preset-env",
+            "//:node_modules/babel-plugin-transform-import-meta",
             "//:package_json",
         ],
         node_modules = "//:node_modules",

--- a/e2e/cli/e2e.bats
+++ b/e2e/cli/e2e.bats
@@ -63,7 +63,7 @@ mock_attestation() {
     cp -R "${FIXTURE}" "${TEST_TMPDIR}/"
     FIXTURE="${TEST_TMPDIR}/$(basename "${FIXTURE}")"
     TEMPLATES_DIR="${FIXTURE}/.bcr"
-    RELEASE_ARCHIVE="e2e/fixtures/versioned-versioned-1.0.0.tar"
+    RELEASE_ARCHIVE="e2e/fixtures/versioned-versioned-1.0.0.tar.gz"
 
     swap_source_url "${TEMPLATES_DIR}/source.template.json" "file://$(realpath "${RELEASE_ARCHIVE}")"
 
@@ -105,7 +105,7 @@ mock_attestation() {
     cp -R "${FIXTURE}" "${TEST_TMPDIR}/"
     FIXTURE="${TEST_TMPDIR}/$(basename "${FIXTURE}")"
     TEMPLATES_DIR="${FIXTURE}/.bcr"
-    RELEASE_ARCHIVE="e2e/fixtures/attestations-attestations-1.0.0.tar"
+    RELEASE_ARCHIVE="e2e/fixtures/attestations-attestations-1.0.0.tar.gz"
 
     SOURCE_ATTESTATION=$(mock_attestation "source.json.intoto.jsonl")
     MODULE_ATTESTATION=$(mock_attestation "MODULE.bazel.intoto.jsonl")
@@ -130,7 +130,7 @@ mock_attestation() {
     cp -R "${FIXTURE}" "${TEST_TMPDIR}/"
     FIXTURE="${TEST_TMPDIR}/$(basename "${FIXTURE}")"
     TEMPLATES_DIR="${FIXTURE}/.bcr"
-    RELEASE_ARCHIVE="e2e/fixtures/versioned-versioned-1.0.0.tar"
+    RELEASE_ARCHIVE="e2e/fixtures/versioned-versioned-1.0.0.tar.gz"
 
     swap_source_url "${TEMPLATES_DIR}/source.template.json" "file://$(realpath "${RELEASE_ARCHIVE}")"
 
@@ -146,7 +146,7 @@ mock_attestation() {
     cp -R "${FIXTURE}" "${TEST_TMPDIR}/"
     FIXTURE="${TEST_TMPDIR}/$(basename "${FIXTURE}")"
     TEMPLATES_DIR="${FIXTURE}/.bcr"
-    RELEASE_ARCHIVE="e2e/fixtures/versioned-versioned-1.0.0.tar"
+    RELEASE_ARCHIVE="e2e/fixtures/versioned-versioned-1.0.0.tar.gz"
 
     swap_source_url "${TEMPLATES_DIR}/source.template.json" "file://$(realpath "${RELEASE_ARCHIVE}")"
 

--- a/e2e/fixtures/BUILD.bazel
+++ b/e2e/fixtures/BUILD.bazel
@@ -3,69 +3,69 @@ load(":fixture.bzl", "fixture_archive")
 
 fixture_archive(
     name = "attestations",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = "attestations-1.0.0",
 )
 
 fixture_archive(
     name = "empty-prefix",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = None,
 )
 
 fixture_archive(
     name = "fixed-releaser",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = "fixed-releaser-1.0.0",
 )
 
 fixture_archive(
     name = "multi-module",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = "multi-module-1.0.0",
 )
 
 fixture_archive(
     name = "multi-module_invalid_prefix",
-    archive = "tar",
+    archive = "tar.gz",
     fixture = "multi-module",
     prefix = "invalid-prefix",
 )
 
 fixture_archive(
     name = "no-prefix",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = None,
 )
 
 fixture_archive(
     name = "tarball",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = "tarball-1.0.0",
 )
 
 fixture_archive(
     name = "unversioned",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = "unversioned-1.0.0",
 )
 
 fixture_archive(
     name = "versioned",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = "versioned-1.0.0",
 )
 
 fixture_archive(
     name = "versioned_invalid_prefix",
-    archive = "tar",
+    archive = "tar.gz",
     fixture = "versioned",
     prefix = "invalid-prefix",
 )
 
 fixture_archive(
     name = "zero-versioned",
-    archive = "tar",
+    archive = "tar.gz",
     prefix = "zero-versioned-1.0.0",
 )
 

--- a/e2e/fixtures/BUILD.bazel
+++ b/e2e/fixtures/BUILD.bazel
@@ -45,6 +45,12 @@ fixture_archive(
 )
 
 fixture_archive(
+    name = "tarball-xz",
+    archive = "tar.xz",
+    prefix = "tarball-xz-1.0.0",
+)
+
+fixture_archive(
     name = "unversioned",
     archive = "tar.gz",
     prefix = "unversioned-1.0.0",

--- a/e2e/fixtures/fixture.bzl
+++ b/e2e/fixtures/fixture.bzl
@@ -3,6 +3,7 @@
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:pkg.bzl", "pkg_tar")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("@rules_xz//xz/compress:defs.bzl", "xz_compress")
 
 def fixture_archive(name, archive, prefix, fixture = None):
     """Create a release archive for a module fixture
@@ -38,5 +39,19 @@ def fixture_archive(name, archive, prefix, fixture = None):
             package_dir = prefix,
             out = "{}-{}.tar.gz".format(fixture, "" if prefix == None else prefix),
             extension = "tar.gz",
+            visibility = ["//e2e:__subpackages__"],
+        )
+    elif archive == "tar.xz":
+        pkg_tar(
+            name = "{}_archive".format(name),
+            srcs = [":{}_files".format(name)],
+            package_dir = prefix,
+            out = "{}-{}.tar".format(fixture, "" if prefix == None else prefix),
+            extension = "tar",
+        )
+
+        xz_compress(
+            name = name,
+            src = "{}_archive".format(name),
             visibility = ["//e2e:__subpackages__"],
         )

--- a/e2e/fixtures/fixture.bzl
+++ b/e2e/fixtures/fixture.bzl
@@ -31,11 +31,12 @@ def fixture_archive(name, archive, prefix, fixture = None):
             out = "{}-{}.zip".format(fixture, "" if prefix == None else prefix),
             visibility = ["//e2e:__subpackages__"],
         )
-    elif archive == "tar":
+    elif archive == "tar.gz":
         pkg_tar(
             name = name,
             srcs = [":{}_files".format(name)],
             package_dir = prefix,
-            out = "{}-{}.tar".format(fixture, "" if prefix == None else prefix),
+            out = "{}-{}.tar.gz".format(fixture, "" if prefix == None else prefix),
+            extension = "tar.gz",
             visibility = ["//e2e:__subpackages__"],
         )

--- a/e2e/fixtures/tarball-xz/.bcr/metadata.template.json
+++ b/e2e/fixtures/tarball-xz/.bcr/metadata.template.json
@@ -1,0 +1,13 @@
+{
+  "homepage": "https://github.com/testorg/tarball-xz",
+  "maintainers": [
+    {
+      "name": "Foo McBar",
+      "email": "foo@test.org",
+      "github": "foobar"
+    }
+  ],
+  "repository": ["github:testorg/tarball-xz"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/e2e/fixtures/tarball-xz/.bcr/presubmit.yml
+++ b/e2e/fixtures/tarball-xz/.bcr/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/e2e/fixtures/tarball-xz/.bcr/source.template.json
+++ b/e2e/fixtures/tarball-xz/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.xz"
+}

--- a/e2e/fixtures/tarball-xz/MODULE.bazel
+++ b/e2e/fixtures/tarball-xz/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "tarball-xz",
+    version = "1.0.0",
+)

--- a/e2e/fixtures/tarball-xz/README.md
+++ b/e2e/fixtures/tarball-xz/README.md
@@ -1,0 +1,1 @@
+Ruleset repo with a .tar.xz release archive extension.

--- a/e2e/github-webhook/BUILD.bazel
+++ b/e2e/github-webhook/BUILD.bazel
@@ -17,6 +17,7 @@ ts_project(
         "//e2e/fixtures:unversioned",
         "//e2e/fixtures:versioned",
         "//e2e/fixtures:versioned_invalid_prefix",
+        "//e2e/fixtures:tarball-xz",
         "//e2e/fixtures:zero-versioned",
         "//e2e/fixtures:zip",
         # e2e tests run a cloud function emulator which runs on the

--- a/e2e/github-webhook/__snapshots__/e2e.spec.js.snap
+++ b/e2e/github-webhook/__snapshots__/e2e.spec.js.snap
@@ -29,7 +29,7 @@ bcr_test_module:
 modules/no-prefix/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-qu7XxK4CB2YfFkceBAkY4mp2klo5bJYU8xQNwUGu1QE=",
+    "integrity": "sha256-dQqjftp7Dsw51+wKoZ7ylYLcU8/OAB82bEhRLVbG5oE=",
     "url": "https://github.com/testorg/no-prefix/archive/refs/tags/v1.0.0.tar.gz"
 }
 
@@ -111,7 +111,7 @@ bcr_test_module:
 modules/empty-prefix/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-WQxg3TTTSIG5+tev5Ult6ek8IKwP+QO+m9/qBAxLsm4=",
+    "integrity": "sha256-3NScfj5InW4kWFD7tHN7nrHo7XirCeZwpEZmUGEumP4=",
     "strip_prefix": "",
     "url": "https://github.com/testorg/empty-prefix/archive/refs/tags/v1.0.0.tar.gz"
 }
@@ -169,7 +169,7 @@ bcr_test_module:
 modules/module/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-TKDqxqkkveSsuYF/j7kP/JI01iijIjtFaWv6ciI5fgo=",
+    "integrity": "sha256-GIERNCByLpef3PWA31F/50ECIeCXV3jcieI/pv1uovg=",
     "strip_prefix": "multi-module-1.0.0",
     "url": "https://github.com/testorg/multi-module/releases/download/v1.0.0.tar.gz"
 }
@@ -223,7 +223,7 @@ bcr_test_module:
 modules/submodule/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-TKDqxqkkveSsuYF/j7kP/JI01iijIjtFaWv6ciI5fgo=",
+    "integrity": "sha256-GIERNCByLpef3PWA31F/50ECIeCXV3jcieI/pv1uovg=",
     "strip_prefix": "multi-module-1.0.0/submodule",
     "url": "https://github.com/testorg/multi-module/releases/download/v1.0.0.tar.gz"
 }
@@ -309,7 +309,7 @@ bcr_test_module:
 modules/attestations/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-R+12jZIR/44X7Tphnee6gygY9XJlYlPCghh1nmsvPHY=",
+    "integrity": "sha256-8Mp0OnyZi6oZkiRyG+7AJ6aKho6Z3FfjVdeO/j+2ZPg=",
     "strip_prefix": "attestations-1.0.0",
     "url": "https://github.com/testorg/attestations/releases/download/v1.0.0/attestations-v1.0.0.tar.gz"
 }
@@ -367,7 +367,7 @@ bcr_test_module:
 modules/tarball/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-IfxRo6OnN+q8mW1TeiWqo+svXpAfCsQ4JsyzPZqnreA=",
+    "integrity": "sha256-5X+xhTuA7pDj/Quebu0vy2HjbV6i9+VCtx07nvDDs2c=",
     "strip_prefix": "tarball-1.0.0",
     "url": "https://github.com/testorg/tarball/archive/refs/tags/v1.0.0.tar.gz"
 }
@@ -437,7 +437,7 @@ bcr_test_module:
 modules/unversioned/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-PQi/tL2WmCaagUGXXGTk3eqa5YIu1V9SHAmWPaVs/3w=",
+    "integrity": "sha256-YsOZo9xaEOEyz4PXwg3Bh3wp+48ASs5FloVLvCEUI4s=",
     "strip_prefix": "unversioned-1.0.0",
     "url": "https://github.com/testorg/unversioned/archive/refs/tags/v1.0.0.tar.gz",
     "patches": {
@@ -499,7 +499,7 @@ bcr_test_module:
 modules/versioned/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-xfjIw3n1H+COtEMgH49j1HCdW0H35vJ2oCrF2W8qelE=",
+    "integrity": "sha256-Fro7OplVkXGdnElWFH/ZOyVL804wFRgSIGgV8nSXfZc=",
     "strip_prefix": "versioned-1.0.0",
     "url": "https://github.com/testorg/versioned/archive/refs/tags/v1.0.0.tar.gz"
 }
@@ -570,7 +570,7 @@ bcr_test_module:
 modules/zero-versioned/1.0.0/source.json
 ----------------------------------------------------
 {
-    "integrity": "sha256-SjKJSF/GuDeTCMYhd9hMkOEjM+r4xP0JSIjP1QzjVco=",
+    "integrity": "sha256-YKWSPs0/a2wizrjaMcotdksAjltxqUMKj4Ut4ZquXms=",
     "strip_prefix": "zero-versioned-1.0.0",
     "url": "https://github.com/testorg/zero-versioned/archive/refs/tags/v1.0.0.tar.gz",
     "patches": {

--- a/e2e/github-webhook/__snapshots__/e2e.spec.js.snap
+++ b/e2e/github-webhook/__snapshots__/e2e.spec.js.snap
@@ -338,6 +338,64 @@ modules/attestations/metadata.json
 "
 `;
 
+exports[`e2e tests [snapshot] ruleset with tar.xz release archive 1`] = `
+"----------------------------------------------------
+modules/tarball-xz/1.0.0/MODULE.bazel
+----------------------------------------------------
+module(
+    name = "tarball-xz",
+    version = "1.0.0",
+)
+
+----------------------------------------------------
+modules/tarball-xz/1.0.0/presubmit.yml
+----------------------------------------------------
+bcr_test_module:
+  module_path: "e2e/bzlmod"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: \${{ platform }}
+      bazel: \${{ bazel }}
+      test_targets:
+        - "//..."
+
+----------------------------------------------------
+modules/tarball-xz/1.0.0/source.json
+----------------------------------------------------
+{
+    "integrity": "sha256-eWwOFAbPPUNnjch/AWrX8Uu8i108b7KdueVSdlODUKU=",
+    "strip_prefix": "tarball-xz-1.0.0",
+    "url": "https://github.com/testorg/tarball-xz/archive/refs/tags/v1.0.0.tar.xz"
+}
+
+----------------------------------------------------
+modules/tarball-xz/metadata.json
+----------------------------------------------------
+{
+    "homepage": "https://github.com/testorg/tarball-xz",
+    "maintainers": [
+        {
+            "name": "Foo McBar",
+            "email": "foo@test.org",
+            "github": "foobar"
+        }
+    ],
+    "repository": [
+        "github:testorg/tarball-xz"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}
+
+"
+`;
+
 exports[`e2e tests [snapshot] ruleset with tarball release archive 1`] = `
 "----------------------------------------------------
 modules/tarball/1.0.0/MODULE.bazel

--- a/e2e/github-webhook/e2e.spec.ts
+++ b/e2e/github-webhook/e2e.spec.ts
@@ -110,7 +110,11 @@ describe('e2e tests', () => {
     const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
-    const releaseArchive = releaseArchivePath(repo, 'unversioned-1.0.0', 'tar');
+    const releaseArchive = releaseArchivePath(
+      repo,
+      'unversioned-1.0.0',
+      'tar.gz'
+    );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -152,7 +156,7 @@ describe('e2e tests', () => {
     const releaseArchive = releaseArchivePath(
       repo,
       'zero-versioned-1.0.0',
-      'tar'
+      'tar.gz'
     );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
@@ -192,7 +196,11 @@ describe('e2e tests', () => {
     const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
-    const releaseArchive = releaseArchivePath(repo, 'versioned-1.0.0', 'tar');
+    const releaseArchive = releaseArchivePath(
+      repo,
+      'versioned-1.0.0',
+      'tar.gz'
+    );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -232,7 +240,7 @@ describe('e2e tests', () => {
     const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
-    const releaseArchive = releaseArchivePath(repo, 'tarball-1.0.0', 'tar');
+    const releaseArchive = releaseArchivePath(repo, 'tarball-1.0.0', 'tar.gz');
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -312,7 +320,7 @@ describe('e2e tests', () => {
     const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
-    const releaseArchive = releaseArchivePath(repo, '', 'tar');
+    const releaseArchive = releaseArchivePath(repo, '', 'tar.gz');
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -352,7 +360,7 @@ describe('e2e tests', () => {
     const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
-    const releaseArchive = releaseArchivePath(repo, '', 'tar');
+    const releaseArchive = releaseArchivePath(repo, '', 'tar.gz');
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -395,7 +403,7 @@ describe('e2e tests', () => {
     const releaseArchive = releaseArchivePath(
       repo,
       'multi-module-1.0.0',
-      'tar'
+      'tar.gz'
     );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/releases/download/${tag}.tar.gz`,
@@ -438,7 +446,7 @@ describe('e2e tests', () => {
     const releaseArchive = releaseArchivePath(
       repo,
       'attestations-1.0.0',
-      'tar'
+      'tar.gz'
     );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/releases/download/${tag}/${repo}-${tag}.tar.gz`,
@@ -490,7 +498,11 @@ describe('e2e tests', () => {
     const rulesetInstallationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
-    const releaseArchive = releaseArchivePath(repo, 'versioned-1.0.0', 'tar');
+    const releaseArchive = releaseArchivePath(
+      repo,
+      'versioned-1.0.0',
+      'tar.gz'
+    );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -583,7 +595,7 @@ describe('e2e tests', () => {
     const releaseArchive = releaseArchivePath(
       repo,
       'multi-module-1.0.0',
-      'tar'
+      'tar.gz'
     );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/releases/download/${tag}.tar.gz`,
@@ -653,7 +665,7 @@ describe('e2e tests', () => {
     const releaseArchive = releaseArchivePath(
       repo,
       'fixed-releaser-1.0.0',
-      'tar'
+      'tar.gz'
     );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
@@ -698,7 +710,11 @@ describe('e2e tests', () => {
     const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(releaser.login!, 'bazel-central-registry');
 
-    const releaseArchive = releaseArchivePath(repo, 'versioned-1.0.0', 'tar');
+    const releaseArchive = releaseArchivePath(
+      repo,
+      'versioned-1.0.0',
+      'tar.gz'
+    );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -749,7 +765,11 @@ describe('e2e tests', () => {
     // App not installed to fork
     // fakeGitHub.mockAppInstallation(testOrg, "bazel-central-registry");
 
-    const releaseArchive = releaseArchivePath(repo, 'versioned-1.0.0', 'tar');
+    const releaseArchive = releaseArchivePath(
+      repo,
+      'versioned-1.0.0',
+      'tar.gz'
+    );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -802,7 +822,11 @@ describe('e2e tests', () => {
     const installationId = fakeGitHub.mockAppInstallation(testOrg, repo);
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
-    const releaseArchive = releaseArchivePath(repo, 'versioned-1.0.0', 'tar');
+    const releaseArchive = releaseArchivePath(
+      repo,
+      'versioned-1.0.0',
+      'tar.gz'
+    );
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -849,7 +873,7 @@ describe('e2e tests', () => {
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
     // Strip prefix in release archive doesn't match source.template.json
-    const releaseArchive = releaseArchivePath(repo, 'invalid-prefix', 'tar');
+    const releaseArchive = releaseArchivePath(repo, 'invalid-prefix', 'tar.gz');
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -892,7 +916,7 @@ describe('e2e tests', () => {
     fakeGitHub.mockAppInstallation(testOrg, 'bazel-central-registry');
 
     // Strip prefix in release archive doesn't match source.template.json
-    const releaseArchive = releaseArchivePath(repo, 'invalid-prefix', 'tar');
+    const releaseArchive = releaseArchivePath(repo, 'invalid-prefix', 'tar.gz');
     await fakeGitHub.mockReleaseArtifact(
       `/${testOrg}/${repo}/archive/refs/tags/${tag}.tar.gz`,
       releaseArchive
@@ -994,7 +1018,7 @@ export function mockSecrets(
 function releaseArchivePath(
   fixture: Fixture,
   stripPrefix: string,
-  ext: 'tar' | 'zip'
+  ext: 'tar.gz' | 'zip'
 ) {
   return path.join('e2e', 'fixtures', `${fixture}-${stripPrefix}.${ext}`);
 }

--- a/e2e/github-webhook/helpers/fixture.ts
+++ b/e2e/github-webhook/helpers/fixture.ts
@@ -16,6 +16,7 @@ export enum Fixture {
   MultiModule = 'multi-module',
   NoPrefix = 'no-prefix',
   Tarball = 'tarball',
+  TarballXz = 'tarball-xz',
   Unversioned = 'unversioned',
   ZeroVersioned = 'zero-versioned',
   Versioned = 'versioned',

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/tar": "^6.1.10",
     "@types/uuid": "^10.0.0",
     "babel-jest": "^29.7.0",
+    "babel-plugin-transform-import-meta": "^2.3.2",
     "eslint": "^9.18.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ devDependencies:
   babel-jest:
     specifier: ^29.7.0
     version: 29.7.0(@babel/core@7.26.0)
+  babel-plugin-transform-import-meta:
+    specifier: ^2.3.2
+    version: 2.3.2(@babel/core@7.26.0)
   eslint:
     specifier: ^9.18.0
     version: 9.18.0
@@ -3029,6 +3032,16 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.26.0)
+    dev: true
+
+  /babel-plugin-transform-import-meta@2.3.2(@babel/core@7.26.0):
+    resolution: {integrity: sha512-902o4GiQqI1GqAXfD5rEoz0PJamUfJ3VllpdWaNsFTwdaNjFSFHawvBO+cp5K2j+g2h3bZ4lnM1Xb6yFYGihtA==}
+    peerDependencies:
+      '@babel/core': ^7.10.0
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/template': 7.25.9
+      tslib: 2.8.1
     dev: true
 
   /babel-preset-current-node-syntax@1.1.0(@babel/core@7.26.0):

--- a/src/infrastructure/xzdec/xzdec.ts
+++ b/src/infrastructure/xzdec/xzdec.ts
@@ -1,6 +1,10 @@
 import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
 import stream from 'node:stream';
+import { fileURLToPath } from 'node:url';
 import zlib from 'node:zlib';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const LZMA_CONCATENATED = 0x08;
 
@@ -64,7 +68,7 @@ interface xzdec_exports {
 let moduleOnce: Promise<WebAssembly.Module> = null;
 
 async function loadXzdec(): Promise<WebAssembly.Module> {
-  const wasmPath = './infrastructure/xzdec/xzdec.wasm.gz';
+  const wasmPath = join(__dirname, 'xzdec.wasm.gz');
   const wasmGzBytes = await fs.readFile(wasmPath);
   const wasmBytes = new Uint8Array(zlib.gunzipSync(wasmGzBytes));
   return await WebAssembly.compile(wasmBytes);


### PR DESCRIPTION
Now that the repository has converted to bazel, we can bring in `rules_xz` to prepare a compressed xz fixture to test.