### PR TITLE
fix: tweak the delay factor when downloading artifacts

### DIFF
--- a/src/domain/artifact.spec.ts
+++ b/src/domain/artifact.spec.ts
@@ -67,7 +67,7 @@ describe('Artifact', () => {
 
       expect(axiosRetry).toHaveBeenCalledWith(axios, {
         retries: 3,
-
+        onRetry: expect.any(Function),
         retryCondition: expect.matchesPredicate(
           // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
           (retryConditionFn: Function) => {
@@ -79,21 +79,18 @@ describe('Artifact', () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
         retryDelay: expect.matchesPredicate((retryDelayFn: Function) => {
           // Make sure the retry delays follow exponential backoff
-          // and the final retry happens after at least 1 minute total
-          // (in this case, at least 70 seconds).
-          // Axios randomly adds an extra 0-20% of jitter to each delay.
-          // Test upper bounds as well to ensure the workflow completes reasonably quickly
-          // (in this case, no more than 84 seconds total).
+          // Axios randomly adds an extra 0-20% of jitter to each delay:
+          // https://github.com/softonic/axios-retry/blob/3f9557920b816ec4f692870d89939ae739d7f8ed/src/index.ts#L169
           const firstRetryDelay = retryDelayFn.call(this, 0);
           const secondRetryDelay = retryDelayFn.call(this, 1);
           const thirdRetryDelay = retryDelayFn.call(this, 2);
           return (
-            10000 <= firstRetryDelay &&
-            firstRetryDelay <= 12000 &&
-            20000 <= secondRetryDelay &&
-            secondRetryDelay <= 24000 &&
-            40000 <= thirdRetryDelay &&
-            thirdRetryDelay <= 48000
+            2000 <= firstRetryDelay &&
+            firstRetryDelay <= 2400 &&
+            4000 <= secondRetryDelay &&
+            secondRetryDelay <= 4800 &&
+            8000 <= thirdRetryDelay &&
+            thirdRetryDelay <= 9600
           );
         }),
         shouldResetTimeout: true,


### PR DESCRIPTION
Experimentally, I found the current delay factor causes a full retry sequence to take about 2m30s which seems long both for the CLI and for the GitHub app. Tweak the factor to take about 30s and output the retry attempts.


```
Publish to BCR
Loading template files from /home/derek/Code/bazel-lib/.bcr
Creating entry for module version 3.0.0 in /home/derek/Code/bazel-central-registry
Fetching release archive https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.tar.gz
Failed to download artifact; Request failed with status code 404
Retry atempt 1 / 3...
Failed to download artifact; Request failed with status code 404
Retry atempt 2 / 3...
Failed to download artifact; Request failed with status code 404
Retry atempt 3 / 3...
Failed to download release archive https://github.com/bazel-contrib/bazel-lib/releases/download/v3.0.0/bazel-lib-v3.0.0.tar.gz; received status code 404
Double check that the url in /home/derek/Code/bazel-lib/.bcr/source.template.json is correct and that the archive has been uploaded by the time this command is run. 
```