### PR TITLE
feat(action): add module name output

### DIFF
--- a/.github/workflows/action-e2e.yaml
+++ b/.github/workflows/action-e2e.yaml
@@ -30,6 +30,7 @@ jobs:
           cd bazel-central-registry
           git init
       - name: Create entry
+        id: create_entry
         uses: ./this
         with:
           tag: v1.0.0
@@ -39,6 +40,14 @@ jobs:
           local-registry: bazel-central-registry
       - name: Test entry content
         run: this/e2e/action/test-happy-path-content.sh
+      - name: Test output
+        run: |
+          set -o errexit -o nounset -o pipefail -o xtrace
+
+          if [[ "${{ steps.create_entry.outputs.module-name }}" != "versioned" ]]; then
+            echo "Expected output module-name to be 'versioned' but it was '${{ steps.create_entry.outputs.module-name }}'"
+            exit 1
+          fi
   test-github-repository-default:
     # Test that the `github-repository` input defaults to ${{ github.repository }}
     # indirectly by checking the resulting subtituted source.json file in the entry.

--- a/action.yaml
+++ b/action.yaml
@@ -47,6 +47,9 @@ inputs:
     description: 'Directory containing BCR release template files: metadata.template.json, source.template.json, presubmit.yaml, patches/. Equivalent to the .bcr directory required by the legacy GitHub app.'
     required: false
     default: ''
+outputs:
+  module-name:
+    description: Name of the module from MODULE.bazel
 runs:
   using: 'node20'
   main: 'dist/action/index.js'

--- a/src/application/action/main.ts
+++ b/src/application/action/main.ts
@@ -67,6 +67,8 @@ async function main() {
       return;
     }
 
+    core.setOutput('module-name', cliOutput.moduleName);
+
     await attest(inputs, cliOutput!);
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
The module name output is needed by the reusable workflow to include the module name in the created PR title. Note that the module name is not known until the action runs because it's extracted from the MODULE.bazel file in the release archive.