### PR TITLE
Add workflow for producing source tgz with stable checksum

### DIFF
--- a/.github/workflows/release-tgz.yml
+++ b/.github/workflows/release-tgz.yml
@@ -1,0 +1,20 @@
+name: Release
+on: workflow_call
+permissions:
+  contents: write
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine version from tag name
+        id: vars
+        run: echo version="${tag_name#v}" >> $GITHUB_OUTPUT
+        env:
+          tag_name: ${{github.event.release.tag_name}}
+      - name: Package sources into tar.gz
+        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{steps.vars.outputs.version}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
+      - name: Upload release archive
+        run: gh release upload ${{github.event.release.tag_name}} ${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
+        env:
+          GH_TOKEN: ${{github.token}}

--- a/templates/.bcr/source.template.json
+++ b/templates/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
   "strip_prefix": "{REPO}-{VERSION}",
-  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{VERSION}.tar.gz"
 }

--- a/templates/.github/workflows/release-tgz.yml
+++ b/templates/.github/workflows/release-tgz.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine version from tag name
+        id: vars
+        run: echo version="${tag_name#v}" >> $GITHUB_OUTPUT
+        env:
+          tag_name: ${{github.event.release.tag_name}}
+      - name: Package sources into tar.gz
+        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{steps.vars.outputs.version}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
+      - name: Upload release archive
+        run: gh release upload ${{github.event.release.tag_name}} ${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
+        env:
+          GH_TOKEN: ${{github.token}}

--- a/templates/.github/workflows/release-tgz.yml
+++ b/templates/.github/workflows/release-tgz.yml
@@ -1,12 +1,9 @@
 name: Release
-
 on:
   release:
     types: [released]
-
 permissions:
   contents: write
-
 jobs:
   upload:
     runs-on: ubuntu-latest

--- a/templates/.github/workflows/release-tgz.yml
+++ b/templates/.github/workflows/release-tgz.yml
@@ -6,17 +6,4 @@ permissions:
   contents: write
 jobs:
   upload:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Determine version from tag name
-        id: vars
-        run: echo version="${tag_name#v}" >> $GITHUB_OUTPUT
-        env:
-          tag_name: ${{github.event.release.tag_name}}
-      - name: Package sources into tar.gz
-        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{steps.vars.outputs.version}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
-      - name: Upload release archive
-        run: gh release upload ${{github.event.release.tag_name}} ${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
-        env:
-          GH_TOKEN: ${{github.token}}
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/release-tgz.yml@master

--- a/templates/README.md
+++ b/templates/README.md
@@ -135,18 +135,5 @@ permissions:
   contents: write
 jobs:
   upload:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Determine version from tag name
-        id: vars
-        run: echo version="${tag_name#v}" >> $GITHUB_OUTPUT
-        env:
-          tag_name: ${{github.event.release.tag_name}}
-      - name: Package sources into tar.gz
-        run: git ls-tree -r -z --name-only HEAD | tar --null --files-from=- --transform="flags=r;s:^:${{github.event.repository.name}}-${{steps.vars.outputs.version}}/:" --sort=name --mtime=2030-01-01T00:00:00Z --owner=0 --group=0 --numeric-owner --create --gzip --file=${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
-      - name: Upload release archive
-        run: gh release upload ${{github.event.release.tag_name}} ${{github.event.repository.name}}-${{steps.vars.outputs.version}}.tar.gz
-        env:
-          GH_TOKEN: ${{github.token}}
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/release-tgz.yml@master
 ```

--- a/templates/README.md
+++ b/templates/README.md
@@ -128,14 +128,11 @@ which do not have a stable checksum over time and will fail integrity checks.
 
 ```yaml
 name: Release
-
 on:
   release:
     types: [released]
-
 permissions:
   contents: write
-
 jobs:
   upload:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is the workflow I have been using in https://github.com/dtolnay/cxx. Example successful release: https://github.com/bazelbuild/bazel-central-registry/pull/4185.

Related discussion: https://github.com/bazel-contrib/publish-to-bcr/issues/140