### PR TITLE
fix: disregard 'gh pr merge' permission error

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -209,3 +209,8 @@ jobs:
       run: gh pr merge -R "${{ inputs.registry }}" --squash --auto "${{ steps.create-pull-request.outputs.pull-request-number }}"
       env:
         GH_TOKEN: ${{ secrets.publish_token }}
+      # If the user does not have merge permission on the registry repository, gh reports an error
+      # but we treat the job as successful anyway. The pull request will just need to be reviewed by
+      # a maintainer. The expected error looks like:
+      # GraphQL: ${USER} does not have the correct permissions to execute `EnablePullRequestAutoMerge` (enablePullRequestAutoMerge)
+      continue-on-error: true


### PR DESCRIPTION
In https://github.com/bazelbuild/bazel-central-registry/pull/4324, everything has seemingly succeeded, but the publish-to-bcr job in my repo got marked as failed because of this error.

```console
Run gh pr merge -R "bazelbuild/bazel-central-registry" --squash --auto "4324"
  shell: /usr/bin/bash -e {0}
  env:
    VERSION: 1.0.157
    GH_TOKEN: ***
GraphQL: dtolnay does not have the correct permissions to execute `EnablePullRequestAutoMerge` (enablePullRequestAutoMerge)
Error: Process completed with exit code 1.
```

https://github.com/dtolnay/cxx/actions/runs/14463112632/job/40559600788