### PR TITLE
Add bazel 8 and bump platforms in presubmit template

### DIFF
--- a/templates/.bcr/presubmit.yml
+++ b/templates/.bcr/presubmit.yml
@@ -3,8 +3,8 @@
 bcr_test_module:
   module_path: "e2e/bzlmod"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
-    bazel: [6.x, 7.x]
+    platform: ["debian11", "macos", "ubuntu2204", "windows"]
+    bazel: [6.x, 7.x, 8.x]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
- New users should also find Bazel 8 in their template
- Bump Ubuntu and Debian images to more recent versions. Ubuntu 2004 is about to EOL in the next weeks.