### PR TITLE
feat(workflow): don't include 'Publish' in the pr title

### DIFF
--- a/.github/workflows/action-e2e.yaml
+++ b/.github/workflows/action-e2e.yaml
@@ -51,7 +51,7 @@ jobs:
             exit 1
           fi
 
-          EXPECTED="Publish versioned@1.0.0"
+          EXPECTED="versioned@1.0.0"
           ACTUAL="${{ steps.create_entry.outputs.short-description }}"
           if [[ "${ACTUAL}" != "${EXPECTED}" ]]; then
             echo "Expected output short-description to be '${EXPECTED}' but it was '${ACTUAL}'"
@@ -162,7 +162,7 @@ jobs:
             exit 1
           fi
 
-          EXPECTED="Publish {module,submodule}@1.0.0"
+          EXPECTED="{module,submodule}@1.0.0"
           ACTUAL="${{ steps.create_entry.outputs.short-description }}"
           if [[ "${ACTUAL}" != "${EXPECTED}" ]]; then
             echo "Expected output short-description to be '${EXPECTED}' but it was '${ACTUAL}'"

--- a/src/application/action/main.ts
+++ b/src/application/action/main.ts
@@ -71,7 +71,7 @@ async function main() {
     core.setOutput('module-names', moduleNames);
     core.setOutput(
       'short-description',
-      `Publish ${cliOutput.modules.length > 1 ? '{' : ''}${moduleNames}${cliOutput.modules.length > 1 ? '}' : ''}@${inputs.moduleVersion}`
+      `${cliOutput.modules.length > 1 ? '{' : ''}${moduleNames}${cliOutput.modules.length > 1 ? '}' : ''}@${inputs.moduleVersion}`
     );
 
     await attest(inputs, cliOutput!);


### PR DESCRIPTION
All PRs are publishes so adding it is redundant. Only include the module name(s) and vesion.