### PR TITLE
chore: generate release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+# Cut a release whenever a new tag is pushed to the repo.
+# You should use an annotated tag, like `git tag -a v1.2.3`
+# and put the release notes into the commit message for the tag.
+name: Release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          # Use GH feature to populate the changelog automatically
+          generate_release_notes: true


### PR DESCRIPTION
Generate release notes when tagging a release. This will let the reusable workflows users know what changed between releases. In the future, I may publish CLI binaries, but I'm not sure if that will be useful if attestations become necessary.

A follow-up will be to find a way to make this `release` job wait for the buildkite build.

Closes https://github.com/bazel-contrib/publish-to-bcr/issues/265.