### PR TITLE
Correctly indicate `github_user_id` as a number

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -22,12 +22,12 @@ _Note_: Maintainers will be emailed if a release fails.
   "maintainers": [
     {
       // <-- And this
-      "name": "YOUR_NAME",
-      "email": "YOUR_EMAIL",
-      "github": "YOUR_GITHUB_USERNAME",
+      "name": "<YOUR_NAME>",
+      "email": "<YOUR_EMAIL>",
+      "github": "<YOUR_GITHUB_USERNAME>",
       // To find your numeric user ID:
       // curl https://api.github.com/users/YOUR_USERNAME | jq .id
-      "github_user_id": "YOUR_GITHUB_ID_NUMBER"
+      "github_user_id": <YOUR_GITHUB_ID_NUMBER>
     }
   ],
   "repository": [


### PR DESCRIPTION
Address https://github.com/bazelbuild/bazel-central-registry/pull/4589#issuecomment-2881249881