### PR TITLE
Add author_{name,email} and committer_{name,email} Inputs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -94,8 +94,7 @@ on:
           Commit author email for the BCR entry. Defaults to the actor running the GitHub Actions workflow.
         default: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
         type: string
-      # Set committer to the GitHub Actions bot. 
-      # If none provided, the GitHub Actions Bot identity is used.
+      # Default the committer to the GitHub Actions bot
       # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
       committer_name:
         description: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -264,8 +264,8 @@ jobs:
 
         # Set committer to the GitHub Actions bot
         # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
-        COMMITTER_NAME="github-actions[bot]"
-        COMMITTER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
+        COMMITTER_NAME=${{ inputs.committer_name }}
+        COMMITTER_EMAIL=${{ inputs.committer_email }}
 
         # Use an authorized remote url to push to the fork
         git remote add authed-fork https://x-access-token:${{ secrets.publish_token }}@github.com/${REGISTRY_FORK}.git

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -237,8 +237,8 @@ jobs:
       env:
         # Set the author to the actor of this workflow. Use the github-provided
         # noreply email address: https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.
-        AUTHOR_NAME: ${{ github.actor }}
-        AUTHOR_EMAIL: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+        AUTHOR_NAME: "EngFlow GitHub Automation"
+        AUTHOR_EMAIL: "engflow-github-automation+public@engflow.com"
       run: |
         set -o errexit -o nounset -o pipefail
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,12 +86,12 @@ on:
         type: boolean
       author_name:
         description: |
-          The AUTHOR_NAME to be used by git in the push-to-fork step to push into REGISTRY_FORK.
+          Commit author name for the BCR entry. Defaults to the actor running the GitHub Actions workflow.
         default: ${{ github.actor }}
         type: string
       author_email:
         description: |
-          The AUTHOR_EMAIL to be used by git in the push-to-fork step to push into REGISTRY_FORK.
+          Commit author email for the BCR entry. Defaults to the actor running the GitHub Actions workflow.
         default: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
         type: string
       # Set committer to the GitHub Actions bot. 
@@ -99,14 +99,12 @@ on:
       # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
       committer_name:
         description: |
-          The COMMITTER_NAME to be used by git in the push-to-fork step to push into REGISTRY_FORK.
-          Use the default value if you're pushing to https://github.com/bazelbuild/bazel-central-registry
+          Name of the git committer. Defaults to the GitHub Action bot's name.
         default: "github-actions[bot]"
         type: string
       committer_email:
         description: |
-          The COMMITTER_EMAIL to be used by git in the push-to-fork step to push into REGISTRY_FORK.
-          Use the default value if you're pushing to https://github.com/bazelbuild/bazel-central-registry
+          Email of the git committer. Defaults to the GitHub Action bot's email.
         default: "41898282+github-actions[bot]@users.noreply.github.com"
         type: string
     secrets:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,6 +84,26 @@ on:
           See https://github.com/bazel-contrib/publish-to-bcr/issues/261.
         default: true
         type: boolean
+      author_name:
+        description: |
+          TODO.
+        default: ${{ github.actor }}
+        type: string
+      author_email:
+        description: |
+          TODO.
+        default: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+        type: string
+      committer_name:
+        description: |
+          TODO.
+        default: "github-actions[bot]"
+        type: string
+      committer_email:
+        description: |
+          TODO.
+        default: "41898282+github-actions[bot]@users.noreply.github.com"
+        type: string
     secrets:
       publish_token:
         required: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,7 +95,7 @@ on:
         default: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
         type: string
 
-      # Set committer to the GitHub Actions bot
+      # Set committer to the GitHub Actions bot if none provided
       # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
       committer_name:
         description: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -257,8 +257,8 @@ jobs:
       env:
         # Set the author to the actor of this workflow. Use the github-provided
         # noreply email address: https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.
-        AUTHOR_NAME: "EngFlow GitHub Automation"
-        AUTHOR_EMAIL: "engflow-github-automation+public@engflow.com"
+        AUTHOR_NAME: ${{ inputs.author_name }}
+        AUTHOR_EMAIL: ${{ inputs.author_email }}
       run: |
         set -o errexit -o nounset -o pipefail
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -94,6 +94,9 @@ on:
           TODO.
         default: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
         type: string
+
+      # Set committer to the GitHub Actions bot
+      # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
       committer_name:
         description: |
           TODO.
@@ -262,8 +265,6 @@ jobs:
       run: |
         set -o errexit -o nounset -o pipefail
 
-        # Set committer to the GitHub Actions bot
-        # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
         COMMITTER_NAME=${{ inputs.committer_name }}
         COMMITTER_EMAIL=${{ inputs.committer_email }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -262,11 +262,10 @@ jobs:
         # noreply email address: https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address.
         AUTHOR_NAME: ${{ inputs.author_name }}
         AUTHOR_EMAIL: ${{ inputs.author_email }}
+        COMMITTER_NAME: ${{ inputs.committer_name }}
+        COMMITTER_EMAIL: ${{ inputs.committer_email }}
       run: |
         set -o errexit -o nounset -o pipefail
-
-        COMMITTER_NAME=${{ inputs.committer_name }}
-        COMMITTER_EMAIL=${{ inputs.committer_email }}
 
         # Use an authorized remote url to push to the fork
         git remote add authed-fork https://x-access-token:${{ secrets.publish_token }}@github.com/${REGISTRY_FORK}.git

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,25 +86,27 @@ on:
         type: boolean
       author_name:
         description: |
-          TODO.
+          The AUTHOR_NAME to be used by git in the push-to-fork step to push into REGISTRY_FORK.
         default: ${{ github.actor }}
         type: string
       author_email:
         description: |
-          TODO.
+          The AUTHOR_EMAIL to be used by git in the push-to-fork step to push into REGISTRY_FORK.
         default: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
         type: string
-
-      # Set committer to the GitHub Actions bot if none provided
+      # Set committer to the GitHub Actions bot. 
+      # If none provided, the GitHub Actions Bot identity is used.
       # https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
       committer_name:
         description: |
-          TODO.
+          The COMMITTER_NAME to be used by git in the push-to-fork step to push into REGISTRY_FORK.
+          Use the default value if you're pushing to https://github.com/bazelbuild/bazel-central-registry
         default: "github-actions[bot]"
         type: string
       committer_email:
         description: |
-          TODO.
+          The COMMITTER_EMAIL to be used by git in the push-to-fork step to push into REGISTRY_FORK.
+          Use the default value if you're pushing to https://github.com/bazelbuild/bazel-central-registry
         default: "41898282+github-actions[bot]@users.noreply.github.com"
         type: string
     secrets:


### PR DESCRIPTION
We recently needed to change the `AUTHOR_NAME` and `AUTHOR_EMAIL` with which an internal bot triggers a PR to our BCR fork and therefore the commit that eventually lands to https://github.com/bazelbuild/bazel-central-registry 

It probably makes sense to make these two inputs instead of hardcoded.