### PR TITLE
fix: skip attestation tests on pr builds

### DIFF
--- a/.github/workflows/action-e2e.yaml
+++ b/.github/workflows/action-e2e.yaml
@@ -84,6 +84,8 @@ jobs:
   test-attestations:
     # Test that attestations are created when `attest` is set to true
     runs-on: ubuntu-latest
+    # Attestations cannot be used from a fork https://github.com/actions/attest-build-provenance/issues/99
+    if: ${{ github.repository == 'bazel-contrib/publish-to-bcr' }}
     permissions:
       id-token: write
       attestations: write
@@ -117,6 +119,8 @@ jobs:
   test-multi-module:
     # Tests a multi-module publish
     runs-on: ubuntu-latest
+    # Attestations cannot be used from a fork https://github.com/actions/attest-build-provenance/issues/99
+    if: ${{ github.repository == 'bazel-contrib/publish-to-bcr' }}
     permissions:
       id-token: write
       attestations: write


### PR DESCRIPTION
Attestations require permissions that aren't available on PR builds. Instead of failing all PRs on CI, skip them and just let main builds detect the error.

Closes https://github.com/bazel-contrib/publish-to-bcr/issues/281.