### PR TITLE
ci: Add GitHub Action to verify PR titles and descriptions

### DIFF
--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,16 @@
+name: Verify PR title/description
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+permissions:
+  pull-requests: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Similar to https://github.com/bazel-contrib/rules-template/pull/167, we add this PR title verification action that helps the to automatically create new releases.

For rules, we use https://github.com/bazel-contrib/rules-template/blob/main/.github/workflows/tag.yaml to automatically create new releases. This requires all commits to follow the conventional commit pattern so that it can automatically derive the next release version based on the commit history. We don't do this yet for the publish-to-bcr action, but eventually this might be a useful feature + following a consistent commit pattern does not hurt.