### PR TITLE
feat(workflow): support deployment environments

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -113,13 +113,23 @@ on:
           With prefix 'bazel-v' and tag 'bazel-v1.2.3', the version becomes '1.2.3'.
         default: "v"
         type: string
+      environment:
+        type: string
+        description: |
+          Name of the deployment environment to use for secrets. Deployment environments cannot be
+          directly passed to reusable workflows: https://github.com/actions/runner/issues/1490.
+        required: false
+        default: "" # Default to no environment
     secrets:
       publish_token:
         required: true
-        description: A Personal Access Token (PAT) used for pushing to a registry fork and opening up a pull request.
+        description: |
+          A Personal Access Token (PAT) used for pushing to a registry fork and opening up a pull request.
+          If a deployment environment is used, the secret will be referenced from the environment.
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     env:
       REGISTRY_BRANCH: ${{ inputs.registry_branch }}
       REGISTRY: ${{ inputs.registry }}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ It requires "workflow" and "repo" permissions.
 > the pull request manually. The fine-grained PAT should be created for the owner of the registry fork.
 
 Save it as `BCR_PUBLISH_TOKEN` in your repository or org, under _Settings > Secrets and variables > Actions_.
+Alternatively, create a GitHub Actions deployment [environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) and save the secret there, then set the name of the environment
+in the `environment` input of the reusable workflow.
 
 > [!TIP]
 >  See an example of [release](https://github.com/aspect-build/rules_lint/blob/main/.github/workflows/release.yml) and [publish](https://github.com/aspect-build/rules_lint/blob/main/.github/workflows/publish.yaml) workflows working together in rules_lint.


### PR DESCRIPTION
The publish token can now be sourced from a deployment [environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments), which offers some additional security guarantees around who can run the workflow.

Manually tested various permutations of the `environment` input (missing, empty, non-existent, existing) and presence of an environment secret on a test repo.

Closes https://github.com/bazel-contrib/publish-to-bcr/issues/294.