### PR TITLE
fix: pass multiple --module-root args

### DIFF
--- a/src/application/action/main.ts
+++ b/src/application/action/main.ts
@@ -70,7 +70,9 @@ async function main() {
     }
 
     if (inputs.moduleRoots && inputs.moduleRoots.length > 0) {
-      cliArgs.push(`--module-roots=${inputs.moduleRoots.join(' ')}`);
+      for (let root of inputs.moduleRoots) {
+        cliArgs.push(`--module-roots=${root}`);
+      }
     }
 
     const { code, output: cliOutput } = await executeCli(cliBin, cliArgs);


### PR DESCRIPTION
Previously a single `--module-roots` option with space-delimited paths was passed from the action to the CLI, e.g.
```
--module-roots . sub/module
```

This is valid when calling the CLI directly from a terminal---yargs will parse this as an array of values. However, when calling from the action with `@actions/exec`'s `exec` method, the spaces appear to be escaped and the whole arg gets treated as a single value. Work around this by just passing multiple instances of the option.

Part of https://github.com/bazel-contrib/publish-to-bcr/issues/368.

Tested in https://github.com/bazel-contrib/publish-to-bcr/pull/392.