### PR TITLE
chore: run action-e2e tests in CI workflow

### DIFF
--- a/.github/workflows/action-e2e.yaml
+++ b/.github/workflows/action-e2e.yaml
@@ -1,16 +1,7 @@
 # End-to-end tests for the Publish to BCR custom GitHub action
 name: action-e2e
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  workflow_dispatch:
-concurrency:
-  # Cancel previous actions from the same PR or branch except 'main' branch.
-  # See https://docs.github.com/en/actions/using-jobs/using-concurrency and https://docs.github.com/en/actions/learn-github-actions/contexts for more info.
-  group: concurrency-group::${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}${{ github.ref_name == 'main' && format('::{0}', github.run_id) || ''}}
-  cancel-in-progress: ${{ github.ref_name != 'main' }}
+  workflow_call:
 jobs:
   # Each job is an e2e test. Unfortunately a full workflow cannot be added as
   # required status check on branch protection rules, so each test must be added

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,3 +71,5 @@ jobs:
           # Don't save cache on pull requests to avoid polluting it
           cache-save: ${{ github.event_name != 'pull_request' }}
       - run: bazel test //... --config=ci
+  action-e2e:
+    uses: ./.github/workflows/action-e2e.yaml


### PR DESCRIPTION
The action e2e tests previously ran independently of the main CI because the action tests had to be run with GHA while the main CI was on Buildkite. Now that all CI runs on GHA, merge the two workflows.

See example [run](https://github.com/bazel-contrib/publish-to-bcr/actions/runs/27098233251?pr=394).