### PR TITLE
fix: update bazel lockfile when autopatching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,7 @@ jobs:
           if ! bazel build //... \
             --config=ci \
             --keep_going \
+            --lockfile_mode=update \ # Renovate might alter package.json whose hash is recorded in the bzlmod lockfile
             --output_groups=autopatch \
             --build_event_json_file="${BUILD_EVENTS}" \
             --remote_download_regex='.*\.patch'; then


### PR DESCRIPTION
Another failure mode of renovate PRs is that they might update a major version in package.json. In that case the bzlmod lockfile also needs to be updated as it records a hash of package.json for the rules_ts extension. Update the lockfile when doing an autopatch run to catch this.

Follow-up to https://github.com/bazel-contrib/publish-to-bcr/commit/ca830b059c3b28733bf08227579041f91356bccc.