### PR TITLE
ci: pin actions in publish.yaml to full-length commit SHAs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -271,7 +271,7 @@ jobs:
     # were already uploaded on a previous run.
     - name: Upload attestations to release
       if: ${{ inputs.attest }}
-      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1 (v0.1.15)
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
       with:
         files: attestations/*
         repository: ${{ inputs.repository }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -181,7 +181,7 @@ jobs:
       TAG_NAME: ${{ inputs.tag_name }}
     steps:
     - name: Checkout the module repository
-      uses: actions/checkout@v4.3.1
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         ref: ${{ inputs.templates_ref || inputs.tag_name }}
         repository: ${{ inputs.repository }}
@@ -189,7 +189,7 @@ jobs:
         persist-credentials: false
 
     - name: Checkout BCR
-      uses: actions/checkout@v4.3.1
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         repository: ${{ inputs.registry }}
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -271,7 +271,7 @@ jobs:
     # were already uploaded on a previous run.
     - name: Upload attestations to release
       if: ${{ inputs.attest }}
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1 (v0.1.15)
       with:
         files: attestations/*
         repository: ${{ inputs.repository }}


### PR DESCRIPTION
## Motivation

GitHub's [**"Require actions to be pinned to a full-length commit SHA"** Actions policy](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/) is enforced against the fully-expanded action graph of a run — including the actions used *inside* a called reusable workflow. When an org/repo has the policy enabled and calls this reusable workflow (`publish.yaml`), the `publish` job fails at *Prepare all required actions*, before any step runs:

```
The actions actions/checkout@v4.3.1 and softprops/action-gh-release@v1 are not allowed
in <repo> because all actions must be pinned to a full-length commit SHA.
```

The policy draws a deliberate line between **actions** and **reusable workflows** (verbatim from GitHub's [enterprise](https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise) / [org](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization) policy docs):

> All actions must be pinned to a full-length commit SHA to be used. This includes actions from your enterprise and actions authored by GitHub.

> Reusable workflows can still be referenced by tag.

So the two references behave differently:

- **The reusable workflow itself stays tag-referenced.** Consumers keep `uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@<tag>` — reusable workflows are exempt from the SHA-pin requirement. This PR does **not** ask anyone to reference `publish.yaml` by SHA.
- **The standard actions used inside `publish.yaml` are not exempt** and are checked against the caller's policy. Those are the only refs that must be pinned, and a policy-constrained consumer cannot fix them from its own side.

Because the workflow reference is unchanged, this is **orthogonal to the BCR attestation policy** (which relies on the workflow being referenced by a tagged version) — that continues to work exactly as before.

`download-artifact` in this file is already SHA-pinned; `checkout` and `action-gh-release` were the only remaining tag refs.

## Change

Pin both actions to the exact commit their current tag resolves to — **no version or behavior change**:

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `@v4.3.1` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1` |
| `softprops/action-gh-release` | `@v1` | `@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1` |

This is consistent with the already-pinned `download-artifact`. Renovate (with `helpers:pinGitHubActionDigests`) can keep the digests updated going forward if desired.
