### PR TITLE
ci: make CI pass for fork PRs

### DIFF
--- a/.github/workflows/action-e2e.yaml
+++ b/.github/workflows/action-e2e.yaml
@@ -75,8 +75,11 @@ jobs:
   test-attestations:
     # Test that attestations are created when `attest` is set to true
     runs-on: ubuntu-latest
-    # Attestations cannot be used from a fork https://github.com/actions/attest-build-provenance/issues/99
-    if: ${{ github.repository == 'bazel-contrib/publish-to-bcr' }}
+    # Attestations require an OIDC id-token, which isn't granted to fork PRs, so
+    # skip these on forks. github.repository is always the base repo for
+    # pull_request events, so compare the PR head repo instead.
+    # https://github.com/actions/attest-build-provenance/issues/99
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       id-token: write
       attestations: write
@@ -110,8 +113,11 @@ jobs:
   test-multi-module:
     # Tests a multi-module publish
     runs-on: ubuntu-latest
-    # Attestations cannot be used from a fork https://github.com/actions/attest-build-provenance/issues/99
-    if: ${{ github.repository == 'bazel-contrib/publish-to-bcr' }}
+    # Attestations require an OIDC id-token, which isn't granted to fork PRs, so
+    # skip these on forks. github.repository is always the base repo for
+    # pull_request events, so compare the PR head repo instead.
+    # https://github.com/actions/attest-build-provenance/issues/99
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       id-token: write
       attestations: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,9 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # Check out the branch rather than a detached commit so that we can
-          # push patched changes if needed.
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Check out the PR head branch (rather than the merge commit) so that
+          # auto-applied patches can be pushed back to it. Fork PRs can't be
+          # pushed to and their head branch doesn't exist in this repo, so fall
+          # back to the default checkout (the merge ref) for them.
+          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.head.ref || '' }}
       - uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
         with:
           # Avoid downloading Bazel every time.
@@ -75,16 +77,20 @@ jobs:
           # Don't save cache on pull requests to avoid polluting it
           cache-save: ${{ github.event_name != 'pull_request' }}
       - run: bazel test //... --config=ci
-      - if: failure() && github.event_name == 'pull_request'
+      # Only same-repo PRs can be pushed to; fork PRs get a read-only token and
+      # their head branch lives in another repo.
+      - if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         name: Apply patches and re-test
         run: |
           BUILD_EVENTS=$(mktemp)
 
-          # Build targets that produce source file patches
+          # Build targets that produce source file patches.
+          # --lockfile_mode=update: Renovate might alter package.json whose hash
+          # is recorded in the bzlmod lockfile.
           if ! bazel build //... \
             --config=ci \
             --keep_going \
-            --lockfile_mode=update \ # Renovate might alter package.json whose hash is recorded in the bzlmod lockfile
+            --lockfile_mode=update \
             --output_groups=autopatch \
             --build_event_json_file="${BUILD_EVENTS}" \
             --remote_download_regex='.*\.patch'; then


### PR DESCRIPTION
## Motivation

Three CI checks failed on fork PR #404 for reasons entirely unrelated to that PR's contents (it only pinned action SHAs). They are all latent **fork-PR** bugs in the workflows, so any external contribution hits them:

| Check | Failure |
| --- | --- |
| `test` | `The process '/usr/bin/git' failed with exit code 1` during checkout, then `The 'test' command is only supported from within a workspace` |
| `action-e2e / test-attestations` | `Failed to get ID token: ... Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` |
| `action-e2e / test-multi-module` | same id-token failure |

### Root causes

**`test` job — checkout used the head *ref* but not the head *repo*.**
```yaml
ref: ${{ github.event.pull_request.head.ref }}
```
`actions/checkout` defaults `repository` to `github.repository` (the *base* repo). For a fork PR, `head.ref` (e.g. `harden/sha-pin-publish-actions`) doesn't exist in the base repo, so `git fetch` fails, the checkout errors out, and the subsequent `bazel test` runs outside any workspace.

**`test-attestations` / `test-multi-module` — the fork guard never fired.**
```yaml
# Attestations cannot be used from a fork ...
if: ${{ github.repository == 'bazel-contrib/publish-to-bcr' }}
```
For `pull_request` events `github.repository` is *always* the base repo, so this condition is true even for fork PRs. The jobs therefore ran on forks and failed requesting an OIDC id-token that fork PRs aren't granted. The intent was to skip on forks; the check has to compare the PR **head** repo.

## Change

- **`ci.yaml` checkout:** use the head branch only for same-repo PRs; fall back to the default (merge ref) checkout for fork PRs and pushes. No behavior change for same-repo PRs or pushes (the old value was already empty on push).
- **`ci.yaml` "Apply patches and re-test" step:** gate to same-repo PRs — fork PRs get a read-only `GITHUB_TOKEN` and their head branch lives in another repo, so the auto-patch push can't work there anyway.
- **`action-e2e.yaml` attestation jobs:** replace the always-true guard with `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`, which runs on pushes and same-repo PRs and correctly **skips** on fork PRs. Skipped jobs still satisfy the required status checks, so fork PRs stay mergeable.
- **Drive-by:** fix a latent bash bug in the patch step — an inline `# comment` after a `\` line-continuation escaped the space instead of the newline, truncating the `bazel build` command.

## Testing

Workflow YAML validated locally. The `test-*` fork guards evaluate to skip on this very PR's fork run and to run on same-repo/push events; the `test` job now checks out the merge ref on forks instead of failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)